### PR TITLE
Fix install.sh crash on empty or invalid MCP config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,18 @@ patch_mcpservers_url() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+
+c = load_json_or_empty(f)
 os.makedirs(os.path.dirname(f), exist_ok=True)
 c.setdefault("mcpServers", {})
 e = {"url": u}
@@ -66,7 +77,16 @@ patch_windsurf() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+c = load_json_or_empty(f)
 os.makedirs(os.path.dirname(f), exist_ok=True)
 c.setdefault("mcpServers", {})
 e = {"serverUrl": u}
@@ -82,7 +102,16 @@ patch_vscode() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+c = load_json_or_empty(f)
 os.makedirs(os.path.dirname(f), exist_ok=True)
 c.setdefault("servers", {})
 e = {"type": "http", "url": u}
@@ -98,7 +127,16 @@ patch_claude_code() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+c = load_json_or_empty(f)
 c.setdefault("mcpServers", {})
 e = {"type": "http", "url": u}
 if k: e["headers"] = {"Authorization": f"Bearer {k}"}
@@ -113,7 +151,16 @@ patch_claude_desktop() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+c = load_json_or_empty(f)
 os.makedirs(os.path.dirname(f), exist_ok=True)
 c.setdefault("mcpServers", {})
 a = ["-y", "mcp-remote@latest", u]
@@ -129,7 +176,16 @@ patch_opencode() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+c = load_json_or_empty(f)
 os.makedirs(os.path.dirname(f), exist_ok=True)
 c.setdefault("mcp", {})
 e = {"type": "remote", "url": u, "enabled": True}
@@ -145,7 +201,16 @@ patch_zed() {
   python3 - "$1" "$MCP_URL" "$INVITE_KEY" << 'PYEOF'
 import json, sys, os
 f, u, k = sys.argv[1], sys.argv[2], sys.argv[3]
-c = json.load(open(f)) if os.path.exists(f) else {}
+def load_json_or_empty(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+c = load_json_or_empty(f)
 os.makedirs(os.path.dirname(f), exist_ok=True)
 c.setdefault("context_servers", {})
 e = {"url": u}

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -1,0 +1,107 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+def run_install(home: Path, prompt_input: str = "n\n"):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+
+    return subprocess.run(
+        ["sh", str(INSTALL_SH)],
+        input=prompt_input,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_install_sh_creates_cursor_config_for_fresh_install(tmp_path):
+    (tmp_path / ".cursor").mkdir()
+
+    result = run_install(tmp_path)
+
+    assert result.returncode == 0
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    assert config_path.exists()
+
+    config = json.loads(config_path.read_text())
+    assert config["mcpServers"]["engram"]["url"] == "https://www.engram-us.com/mcp"
+
+
+def test_install_sh_merges_with_existing_cursor_config(tmp_path):
+    cursor_dir = tmp_path / ".cursor"
+    cursor_dir.mkdir()
+
+    config_path = cursor_dir / "mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "other": {
+                        "url": "https://example.com/mcp"
+                    }
+                }
+            }
+        )
+    )
+
+    result = run_install(tmp_path)
+
+    assert result.returncode == 0
+
+    config = json.loads(config_path.read_text())
+    assert config["mcpServers"]["other"]["url"] == "https://example.com/mcp"
+    assert config["mcpServers"]["engram"]["url"] == "https://www.engram-us.com/mcp"
+
+
+def test_install_sh_adds_invite_key_header(tmp_path):
+    (tmp_path / ".cursor").mkdir()
+
+    result = run_install(tmp_path, "y\nek_live_test123\n")
+
+    assert result.returncode == 0
+
+    config_path = tmp_path / ".cursor" / "mcp.json"
+    config = json.loads(config_path.read_text())
+
+    assert (
+        config["mcpServers"]["engram"]["headers"]["Authorization"]
+        == "Bearer ek_live_test123"
+    )
+
+
+def test_install_sh_handles_empty_existing_json_file(tmp_path):
+    cursor_dir = tmp_path / ".cursor"
+    cursor_dir.mkdir()
+
+    config_path = cursor_dir / "mcp.json"
+    config_path.write_text("")
+
+    result = run_install(tmp_path)
+
+    assert result.returncode == 0
+
+    config = json.loads(config_path.read_text())
+    assert config["mcpServers"]["engram"]["url"] == "https://www.engram-us.com/mcp"
+
+
+def test_install_sh_handles_invalid_existing_json_file(tmp_path):
+    cursor_dir = tmp_path / ".cursor"
+    cursor_dir.mkdir()
+
+    config_path = cursor_dir / "mcp.json"
+    config_path.write_text("{invalid json")
+
+    result = run_install(tmp_path)
+
+    assert result.returncode == 0
+
+    config = json.loads(config_path.read_text())
+    assert config["mcpServers"]["engram"]["url"] == "https://www.engram-us.com/mcp"


### PR DESCRIPTION
## Summary
Fixes a crash in `install.sh` when an existing MCP config file is present but empty or malformed.

## What changed
- Added safe JSON loading in the shell installer patchers
- Treats empty config files as empty objects instead of crashing
- Handles malformed JSON without raising `JSONDecodeError`
- Added regression tests for:
  - fresh Cursor config creation
  - merge with existing Cursor config
  - invite key header injection
  - empty existing JSON file
  - invalid existing JSON file

## Why
I reproduced a crash locally when `.cursor/mcp.json` existed but was empty or contained invalid JSON. Since the macOS/Linux quick-start path uses `curl ... | sh`, installer robustness matters.

## How I tested
- Ran the existing test suite
- Added installer regression tests using a temporary `HOME`
- Verified all tests pass (`57 passed`)
- Manually reproduced and re-tested the empty-file and invalid-JSON cases