### PR TITLE
Fix duplicate score calculation and async task cleanup in query engine

### DIFF
--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -469,17 +469,6 @@ class EngramEngine:
             ):
                 score *= 0.3
 
-            # Combined score with enhanced signals
-            score = (
-                relevance
-                + 0.2 * recency
-                + 0.15 * trust
-                + 0.1 * fact_type_weight
-                + 0.1 * provenance_weight
-                + 0.1 * corroboration_weight
-                + 0.05 * entity_density
-            )
-
             # Ephemeral facts rank lower than durable facts
             if fact.get("durability") == "ephemeral":
                 score *= 0.6
@@ -684,6 +673,11 @@ class EngramEngine:
         except asyncio.CancelledError:
             for t in list(active):
                 t.cancel()
+            for t in list(active):
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):
+                    pass
 
     async def _detect_with_semaphore(
         self, fact_id: str, semaphore: asyncio.Semaphore


### PR DESCRIPTION
## Summary

Found two bugs in `engine.py` while exploring the codebase:

### Bug 1: Duplicate score calculation (lines 452-481)

The query scoring pipeline computed the combined score **twice** with different weights. The second calculation (lines 473-481) silently overwrote the first, which caused:
- **Supersession penalty** was applied in the first score but lost in the second
- **Unverified inference decay** (the 0.3 penalty for old unconfirmed guesses) was applied between the two calculations, then the entire score was replaced
- **Recency weight** differed (0.25 vs 0.20) and **fact_type_weight** differed (0.15 vs 0.10)

**Fix:** Removed the duplicate second calculation, keeping the first which correctly applies supersession_penalty and preserves all downstream penalties.

### Bug 2: Detection worker async cleanup (line 684-686)

When the detection worker is cancelled, it cancels all active tasks but does not `await` them. This can leave the asyncio semaphore in an inconsistent state if tasks are cancelled while blocked on semaphore acquisition.

**Fix:** Added `await` on all cancelled tasks with proper exception handling.

## Test plan

- [x] All 52 existing tests pass (5 test_install_sh failures are pre-existing on Windows)
- [x] Score calculation now correctly applies supersession penalty and inference decay
- [x] Detection worker cleanup properly awaits cancelled tasks
