### PR TITLE
Add proactive commit suggestions

### DIFF
--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -80,6 +80,54 @@ class EngramEngine:
         self._escalation_task = None
         self._webhook_task = None
 
+    def _build_commit_suggestions(
+        self,
+        content: str,
+        scope: str,
+        keywords: list[str] | None = None,
+        entities: list[dict[str, Any]] | None = None,
+    ) -> list[str]:
+        text = content.lower()
+        suggestions: list[str] = []
+
+        def add(msg: str) -> None:
+            if msg not in suggestions and len(suggestions) < 2:
+                suggestions.append(msg)
+
+        if "rate limit" in text or "rate-limit" in text:
+            add("Consider also committing the retry strategy.")
+            add("Consider also committing the circuit breaker threshold.")
+
+        if "retry" in text or "backoff" in text:
+            add("Consider also committing the max retry count.")
+            add("Consider also committing the timeout behavior.")
+
+        if "timeout" in text:
+            add("Consider also committing the retry policy.")
+            add("Consider also committing the circuit breaker threshold.")
+
+        if "webhook" in text:
+            add("Consider also committing the retry behavior.")
+            add("Consider also committing the signature validation rule.")
+
+        if "cache" in text:
+            add("Consider also committing the cache TTL.")
+            add("Consider also committing the invalidation strategy.")
+
+        if "queue" in text or "worker" in text:
+            add("Consider also committing the retry policy.")
+            add("Consider also committing the dead-letter queue behavior.")
+
+        if "database" in text or "postgres" in text or "mysql" in text:
+            add("Consider also committing the connection pool settings.")
+            add("Consider also committing the migration or schema dependency.")
+
+        if "auth" in text or "token" in text or "jwt" in text:
+            add("Consider also committing the token expiry behavior.")
+            add("Consider also committing the refresh or revocation flow.")
+
+        return suggestions
+
     # ── engram_commit ────────────────────────────────────────────────
 
     async def commit(
@@ -135,6 +183,7 @@ class EngramEngine:
                 "duplicate": False,
                 "conflicts_detected": False,
                 "memory_op": "none",
+                "suggestions": [],
             }
 
         # delete — close an existing lineage and return without a new fact
@@ -152,6 +201,7 @@ class EngramEngine:
                 "conflicts_detected": False,
                 "memory_op": "delete",
                 "deleted_lineage": corrects_lineage,
+                "suggestions": [],
             }
 
         if not content or not content.strip():
@@ -199,6 +249,7 @@ class EngramEngine:
                 "committed_at": datetime.now(timezone.utc).isoformat(),
                 "duplicate": True,
                 "conflicts_detected": False,
+                "suggestions": [],
             }
 
         # Step 5: Generate embedding
@@ -208,6 +259,13 @@ class EngramEngine:
         # Step 6: Extract keywords and entities
         keywords = extract_keywords(content)
         entities = extract_entities(content)
+
+        suggestions = self._build_commit_suggestions(
+            content=content,
+            scope=scope,
+            keywords=keywords,
+            entities=entities,
+        )
 
         # Step 7: Determine agent_id
         if not agent_id:
@@ -336,6 +394,7 @@ class EngramEngine:
             "memory_op": operation,
             "supersedes_fact_id": supersedes_fact_id,
             "durability": durability,
+            "suggestions": suggestions,
         }
 
         # Audit + fire event (fire-and-forget; errors must not block the commit)

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -595,7 +595,7 @@ async def engram_commit(
                      or context that hasn't proven its value yet.
 
     Returns: {fact_id, committed_at, duplicate, conflicts_detected,
-              memory_op, supersedes_fact_id, durability}
+              memory_op, supersedes_fact_id, durability, suggestions}
     """
     engine = get_engine()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,6 +22,24 @@ async def test_commit_basic(engine: EngramEngine):
     assert result["duplicate"] is False
     assert "fact_id" in result
     assert "committed_at" in result
+    assert "suggestions" in result
+    assert isinstance(result["suggestions"], list)
+    assert len(result["suggestions"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_commit_returns_proactive_suggestions_for_rate_limit(engine: EngramEngine):
+    result = await engine.commit(
+        content="The auth service rate limit is 1000 req/s per IP",
+        scope="auth",
+        confidence=0.9,
+        agent_id="agent-1",
+    )
+
+    assert "suggestions" in result
+    assert isinstance(result["suggestions"], list)
+    assert len(result["suggestions"]) <= 2
+    assert any("retry" in s.lower() for s in result["suggestions"])
 
 
 @pytest.mark.asyncio
@@ -39,6 +57,21 @@ async def test_commit_dedup(engine: EngramEngine):
         agent_id="agent-2",
     )
     assert result2["duplicate"] is True
+    assert result2["suggestions"] == []
+
+
+@pytest.mark.asyncio
+async def test_commit_none_operation_returns_empty_suggestions(engine: EngramEngine):
+    result = await engine.commit(
+        content="No new fact to add",
+        scope="general",
+        confidence=0.8,
+        operation="none",
+    )
+
+    assert result["memory_op"] == "none"
+    assert result["fact_id"] is None
+    assert result["suggestions"] == []
 
 
 @pytest.mark.asyncio
@@ -362,6 +395,7 @@ async def test_commit_delete_operation(engine: EngramEngine):
     )
     assert result["memory_op"] == "delete"
     assert result["deleted_lineage"] == lineage
+    assert result["suggestions"] == []
 
     # Original fact must be retired
     retired = await engine.storage.get_fact_by_id(r1["fact_id"])


### PR DESCRIPTION
## Summary

Adds proactive follow-up suggestions to `engram_commit` responses.

After a successful commit, Engram now returns up to two related facts the agent may also want to commit, making the system more proactive instead of purely reactive.

## What changed

- added lightweight post-commit suggestion generation in `EngramEngine`
- returned `suggestions` in commit responses
- kept duplicate, delete, and no-op commit responses consistent with `suggestions: []`
- updated the `engram_commit` return contract docstring to include `suggestions`
- added focused engine tests for proactive suggestions and response shape

## Why

This helps agents preserve more complete knowledge in a single pass. For example, after committing a rate limit, Engram can suggest also committing the retry strategy or circuit breaker threshold.

## Validation

- `pytest -q tests/test_engine.py`
- `ruff check .`
- manually verified `/api/commit` returns `suggestions` for a new rate-limit fact