### PR TITLE
Extracted names of agents from CLI into a data file

### DIFF
--- a/src/data/cli-agent-clients.json
+++ b/src/data/cli-agent-clients.json
@@ -1,0 +1,421 @@
+{
+    "5ire": {
+        "path": "5ire/mcp_config.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "Aider": {
+        "path": ".aider/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Amazon Q Developer CLI": {
+        "path": ".aws/amazonq/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Augment Code": {
+        "path": ".augment/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "BoltAI": {
+        "path": "BoltAI/mcp_config.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "ChatBox": {
+        "path": "xyz.chatboxapp.app/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "Cherry Studio": {
+        "path": "CherryStudio/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "Claude Code": {
+        "path": ".claude/settings.json",
+        "server_type_key": "mcpServers",
+        "family": "Anthropic",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Claude Desktop": {
+        "path": "Claude/claude_desktop_config.json",
+        "server_type_key": "mcpServers",
+        "family": "Anthropic",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Cline": {
+        "path": ".vscode/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Cline (VS Code Insiders)": {
+        "path": ".vscode-insiders/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Codex": {
+        "path": ".codex/config.toml",
+        "server_type_key": "mcp_servers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        },
+        "format": "toml"
+    },
+    "Cody (Sourcegraph)": {
+        "path": "cody/mcp_servers.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": true,
+            "syshome": false
+        }
+    },
+    "Continue": {
+        "path": ".continue/config.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Cursor": {
+        "path": ".cursor/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Devin CLI": {
+        "path": "devin/config.json",
+        "server_type_key": "mcpServers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": true,
+            "syshome": false
+        }
+    },
+    "Dive": {
+        "path": "Dive/mcp_config.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "Emacs (mcp.el)": {
+        "path": ".emacs.d/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "Editor",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Gemini CLI": {
+        "path": ".gemini/settings.json",
+        "server_type_key": "mcpServers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "GitHub Copilot CLI": {
+        "path": ".copilot/mcp-config.json",
+        "server_type_key": "mcpServers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Highlight AI": {
+        "path": "Highlight/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "HyperChat": {
+        "path": "HyperChat/mcp_config.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "IntelliJ Idea (JetBrains)": {
+        "path": ".idea/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Kiro (Amazon)": {
+        "path": ".kiro/settings/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "msty": {
+        "path": "msty/mcp_config.json",
+        "server_type_key": "mcpServers",
+        "family": "Desktop",
+        "config_path": {
+            "appdata": true,
+            "appsupport": true,
+            "xdg": false,
+            "syshome": false
+        }
+    },
+    "Neovim (mcphub.nvim)": {
+        "path": "mcphub/servers.json",
+        "server_type_key": "mcpServers",
+        "family": "Editor",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": true,
+            "syshome": false
+        }
+    },
+    "OpenCode": {
+        "path": "opencode/opencode.json",
+        "server_type_key": "mcp",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": true,
+            "syshome": false
+        }
+    },
+    "Qwen Code": {
+        "path": ".qwen-code/settings.json",
+        "server_type_key": "mcpServers",
+        "family": "CLI agents",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Refact.ai": {
+        "path": ".refact/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Roo Code": {
+        "path": ".vscode/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Roo Code (VS Code Insiders)": {
+        "path": ".vscode-insiders/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Theia IDE": {
+        "path": ".theia/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Trae": {
+        "path": ".trae/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "VS Code (Copilot)": {
+        "path": ".vscode/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "VS Code Insiders (Copilot)": {
+        "path": ".vscode-insiders/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "VS Code",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Warp": {
+        "path": ".warp/mcp.json",
+        "server_type_key": "mcpServers",
+        "family": "Terminal",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Windsurf": {
+        "path": ".codeium/windsurf/mcp_config.json",
+        "server_type_key": "mcpServers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": false,
+            "syshome": true
+        }
+    },
+    "Zed": {
+        "path": "zed/settings.json",
+        "server_type_key": "context_servers",
+        "family": "AI-native",
+        "config_path": {
+            "appdata": false,
+            "appsupport": false,
+            "xdg": true,
+            "syshome": false
+        }
+    }
+}

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -13,15 +13,21 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import platform as _platform
 import sys
 from pathlib import Path
+import os
+import platform as _platform
 
 import click
 
 from engram import embeddings
 from engram.storage import DEFAULT_DB_PATH
 
+_DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+_PATH_SYSTEM_HOME = Path.home()
+_PATH_APPDATA_DIR = Path(os.environ["APPDATA"]) if "APPDATA" in os.environ else None
+_PATH_APPSUPPORT_DIR = _PATH_SYSTEM_HOME / "Library" / "Application Support"  # Mac only
+_PATH_XDG_DIR = Path(os.environ["XDG_CONFIG_HOME"]) if "XDG_CONFIG_HOME" in os.environ else None
 
 @click.group()
 def main() -> None:
@@ -31,259 +37,34 @@ def main() -> None:
 
 # ── engram install ───────────────────────────────────────────────────
 
+# Read in the list of known client config locations and get their appropriate
+# config file (different systems have them in different places).
 
-# Known MCP client config locations and the JSON path to mcpServers.
-# Comprehensive list covering all known MCP-compatible IDEs, editors, CLI
-# tools, and desktop apps that store their config in a discoverable file.
-# Entries are grouped by category for readability.
-
-
-def _xdg_config() -> Path:
-    """Return XDG_CONFIG_HOME or its default."""
-    import os
-
-    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
-
-
-def _app_support() -> Path:
-    """macOS ~/Library/Application Support."""
-    return Path.home() / "Library" / "Application Support"
-
-
-def _appdata() -> Path:
-    """Windows %APPDATA% (falls back to ~/.config on non-Windows)."""
-    import os
-
-    return Path(os.environ.get("APPDATA", Path.home() / ".config"))
-
-
-_IS_MAC = _platform.system() == "Darwin"
-_IS_WIN = _platform.system() == "Windows"
-
-_MCP_CLIENTS: dict[str, dict] = {
-    # ── Anthropic ────────────────────────────────────────────────────
-    "Claude Code": {
-        "path": Path.home() / ".claude" / "settings.json",
-        "key": "mcpServers",
-    },
-    "Claude Desktop": {
-        "path": (
-            _app_support() / "Claude" / "claude_desktop_config.json"
-            if _IS_MAC
-            else _appdata() / "Claude" / "claude_desktop_config.json"
-        ),
-        "key": "mcpServers",
-    },
-    # ── VS Code family ──────────────────────────────────────────────
-    "VS Code (Copilot)": {
-        "path": Path.home() / ".vscode" / "mcp.json",
-        "key": "mcpServers",
-    },
-    "VS Code Insiders (Copilot)": {
-        "path": Path.home() / ".vscode-insiders" / "mcp.json",
-        "key": "mcpServers",
-    },
-    "Cline (VS Code)": {
-        "path": Path.home()
-        / ".vscode"
-        / "globalStorage"
-        / "saoudrizwan.claude-dev"
-        / "settings"
-        / "cline_mcp_settings.json",
-        "key": "mcpServers",
-    },
-    "Cline (VS Code Insiders)": {
-        "path": Path.home()
-        / ".vscode-insiders"
-        / "globalStorage"
-        / "saoudrizwan.claude-dev"
-        / "settings"
-        / "cline_mcp_settings.json",
-        "key": "mcpServers",
-    },
-    "Roo Code (VS Code)": {
-        "path": Path.home()
-        / ".vscode"
-        / "globalStorage"
-        / "rooveterinaryinc.roo-cline"
-        / "settings"
-        / "cline_mcp_settings.json",
-        "key": "mcpServers",
-    },
-    "Roo Code (VS Code Insiders)": {
-        "path": Path.home()
-        / ".vscode-insiders"
-        / "globalStorage"
-        / "rooveterinaryinc.roo-cline"
-        / "settings"
-        / "cline_mcp_settings.json",
-        "key": "mcpServers",
-    },
-    "Continue (VS Code)": {
-        "path": Path.home() / ".continue" / "config.json",
-        "key": "mcpServers",
-    },
-    "Sourcegraph Cody": {
-        "path": _xdg_config() / "cody" / "mcp_servers.json",
-        "key": "mcpServers",
-    },
-    # ── AI-native editors ───────────────────────────────────────────
-    "Cursor": {
-        "path": Path.home() / ".cursor" / "mcp.json",
-        "key": "mcpServers",
-    },
-    "Windsurf": {
-        "path": Path.home() / ".codeium" / "windsurf" / "mcp_config.json",
-        "key": "mcpServers",
-    },
-    "Trae": {
-        "path": Path.home() / ".trae" / "mcp.json",
-        "key": "mcpServers",
-    },
-    "Zed": {
-        "path": _xdg_config() / "zed" / "settings.json",
-        "key": "context_servers",  # Zed uses context_servers, not mcpServers
-    },
-    "Augment Code": {
-        "path": Path.home() / ".augment" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── Kiro (Amazon) ───────────────────────────────────────────────
-    "Kiro": {
-        "path": Path.home() / ".kiro" / "settings" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── JetBrains IDEs (shared config location) ─────────────────────
-    "IntelliJ IDEA": {
-        "path": Path.home() / ".idea" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── CLI agents ──────────────────────────────────────────────────
-    "Codex": {
-        "path": Path.home() / ".codex" / "config.toml",
-        "key": "mcp_servers",  # TOML format
-        "format": "toml",
-    },
-    "Amazon Q Developer CLI": {
-        "path": Path.home() / ".aws" / "amazonq" / "mcp.json",
-        "key": "mcpServers",
-    },
-    "GitHub Copilot CLI": {
-        "path": Path.home() / ".copilot" / "mcp-config.json",
-        "key": "mcpServers",
-    },
-    "Gemini CLI": {
-        "path": Path.home() / ".gemini" / "settings.json",
-        "key": "mcpServers",
-    },
-    "OpenCode": {
-        "path": _xdg_config() / "opencode" / "opencode.json",
-        "key": "mcp",
-    },
-    "Devin CLI": {
-        "path": _xdg_config() / "devin" / "config.json",
-        "key": "mcpServers",
-    },
-    "Qwen Code": {
-        "path": Path.home() / ".qwen-code" / "settings.json",
-        "key": "mcpServers",
-    },
-    # ── Desktop chat apps ───────────────────────────────────────────
-    "Cherry Studio": {
-        "path": (
-            _app_support() / "CherryStudio" / "mcp.json"
-            if _IS_MAC
-            else _appdata() / "CherryStudio" / "mcp.json"
-        ),
-        "key": "mcpServers",
-    },
-    "ChatBox": {
-        "path": (
-            _app_support() / "xyz.chatboxapp.app" / "mcp.json"
-            if _IS_MAC
-            else _appdata() / "xyz.chatboxapp.app" / "mcp.json"
-        ),
-        "key": "mcpServers",
-    },
-    "msty": {
-        "path": (
-            _app_support() / "msty" / "mcp_config.json"
-            if _IS_MAC
-            else _appdata() / "msty" / "mcp_config.json"
-        ),
-        "key": "mcpServers",
-    },
-    "Dive": {
-        "path": (
-            _app_support() / "Dive" / "mcp_config.json"
-            if _IS_MAC
-            else _appdata() / "Dive" / "mcp_config.json"
-        ),
-        "key": "mcpServers",
-    },
-    "HyperChat": {
-        "path": (
-            _app_support() / "HyperChat" / "mcp_config.json"
-            if _IS_MAC
-            else _appdata() / "HyperChat" / "mcp_config.json"
-        ),
-        "key": "mcpServers",
-    },
-    "BoltAI": {
-        "path": (
-            _app_support() / "BoltAI" / "mcp_config.json"
-            if _IS_MAC
-            else _appdata() / "BoltAI" / "mcp_config.json"
-        ),
-        "key": "mcpServers",
-    },
-    "5ire": {
-        "path": (
-            _app_support() / "5ire" / "mcp_config.json"
-            if _IS_MAC
-            else _appdata() / "5ire" / "mcp_config.json"
-        ),
-        "key": "mcpServers",
-    },
-    # ── Neovim / Emacs ──────────────────────────────────────────────
-    "Neovim (mcphub.nvim)": {
-        "path": _xdg_config() / "mcphub" / "servers.json",
-        "key": "mcpServers",
-    },
-    "Emacs (mcp.el)": {
-        "path": Path.home() / ".emacs.d" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── Terminal / Warp ─────────────────────────────────────────────
-    "Warp": {
-        "path": Path.home() / ".warp" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── Theia IDE ───────────────────────────────────────────────────
-    "Theia IDE": {
-        "path": Path.home() / ".theia" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── Refact.ai ───────────────────────────────────────────────────
-    "Refact.ai": {
-        "path": Path.home() / ".refact" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── Aider ───────────────────────────────────────────────────────
-    "Aider": {
-        "path": Path.home() / ".aider" / "mcp.json",
-        "key": "mcpServers",
-    },
-    # ── Highlight AI ────────────────────────────────────────────────
-    "Highlight AI": {
-        "path": (
-            _app_support() / "Highlight" / "mcp.json"
-            if _IS_MAC
-            else _appdata() / "Highlight" / "mcp.json"
-        ),
-        "key": "mcpServers",
-    },
-}
+_AGENT_CLIENTS = {}
+with open(os.path.join(_DATA_DIR, 'cli-agent-clients.json'), 'r') as file:
+    agent_clients_json = json.load(file)
+    for key in agent_clients_json.keys():
+        _AGENT_CLIENTS[key] = {}
+        agent_config_path = agent_clients_json[key]['path']
+        if agent_clients_json[key]['config_path']['appdata'] and _PATH_APPDATA_DIR:
+            _AGENT_CLIENTS[key]['path'] = Path(
+                _PATH_APPDATA_DIR / agent_config_path
+            )
+        elif agent_clients_json[key]['config_path']['appsupport'] and _PATH_APPSUPPORT_DIR:
+            _AGENT_CLIENTS[key]['path'] = Path(
+                _PATH_APPSUPPORT_DIR / agent_config_path
+            )
+        elif agent_clients_json[key]['config_path']['xdg'] and _PATH_XDG_DIR:
+            _AGENT_CLIENTS[key]['path'] = Path(
+                _PATH_XDG_DIR / agent_config_path
+            )
+        elif agent_clients_json[key]['config_path']['syshome']:
+            _AGENT_CLIENTS[key]['path'] = Path(
+                _PATH_SYSTEM_HOME / agent_config_path
+            )
+        if 'path' not in _AGENT_CLIENTS[key]:
+            _AGENT_CLIENTS[key]['path'] = Path("ValidPathNotFound")
+        _AGENT_CLIENTS[key]['key'] = agent_clients_json[key]['server_type_key']
 
 _ENGRAM_MCP_ENTRY = {
     "command": "uvx",
@@ -386,7 +167,7 @@ def install(dry_run: bool) -> None:
     skipped = []
     steering_written = []
 
-    for client_name, info in _MCP_CLIENTS.items():
+    for client_name, info in _AGENT_CLIENTS.items():
         config_path: Path = info["path"]
         key: str = info["key"]
         fmt = info.get("format", "json")
@@ -1229,7 +1010,7 @@ def verify(verbose: bool) -> None:
     detected = []
     missing = []
 
-    for client_name, info in _MCP_CLIENTS.items():
+    for client_name, info in _AGENT_CLIENTS.items():
         config_path: Path = info["path"]
         try:
             if config_path.exists():
@@ -1498,7 +1279,7 @@ def setup(
         click.echo("[1/4] Detecting MCP clients...")
         # Reuse the install logic to detect clients
         added = []
-        for client_name, info in _MCP_CLIENTS.items():
+        for client_name, info in _AGENT_CLIENTS.items():
             config_path: Path = info["path"]
             if config_path.exists():
                 added.append(client_name)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -6,16 +6,16 @@ from pathlib import Path
 from unittest.mock import patch
 from click.testing import CliRunner
 
-from engram.cli import main, _MCP_CLIENTS
+from engram.cli import main, _AGENT_CLIENTS
 
 
 _REAL_HOME = Path.home()
 
 
-def _rebased_mcp_clients(home: Path) -> dict:
-    """Rebuild _MCP_CLIENTS with paths rooted under *home*."""
+def _rebased_agent_clients(home: Path) -> dict:
+    """Rebuild _AGENT_CLIENTS with paths rooted under *home*."""
     rebuilt = {}
-    for name, cfg in _MCP_CLIENTS.items():
+    for name, cfg in _AGENT_CLIENTS.items():
         new_cfg = dict(cfg)
         try:
             relative = cfg["path"].relative_to(_REAL_HOME)
@@ -41,7 +41,7 @@ class TestVerifyCommand:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("engram.workspace.WORKSPACE_PATH", workspace_path),
-            patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+            patch("engram.cli._AGENT_CLIENTS", _rebased_agent_clients(tmp_path)),
         ):
             yield tmp_path
 
@@ -237,7 +237,7 @@ class TestVerifyMCPClientDetection:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("engram.workspace.WORKSPACE_PATH", workspace_path),
-            patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+            patch("engram.cli._AGENT_CLIENTS", _rebased_agent_clients(tmp_path)),
         ):
             yield tmp_path
 


### PR DESCRIPTION
The names and properties of the agents in the CLI are now extracted into a JSON data file, with a corresponding data directory now living in src. At the moment, Engram has a lot of hard-coded data in it -- strings, HTML, scripting -- all smushed together into Python. It makes things a lot harder to manage and maintain. I believe my contributions can be disentangling as much of that as possible into data, so we can edit data files rather than code, making both overall maintenance and comprehension easier. This is only the first step in that process, more information can be extracted from the CLI and many other files.