### PR TITLE
Add first-class Windsurf and Zed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Your agent handles the rest.
 
 ---
 
+## First-Class IDE Targets
+
+Engram is currently optimized for MCP-native workflows in:
+
+- [Claude Code](./docs/quickstart/claude-code.md)
+- [Windsurf](./docs/quickstart/windsurf.md)
+- [Zed](./docs/quickstart/zed.md)
+
+Each guide includes the expected MCP config path, restart step, verification flow, and common setup mistakes.
+
+
 ## Running Locally
 
 If you want to run Engram from this repository during development:

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -11,6 +11,7 @@ This directory contains step-by-step setup guides for using Engram with differen
 | VS Code (Copilot) | [vscode-copilot.md](./vscode-copilot.md) | ✓ Complete |
 | Claude Desktop | [claude-desktop.md](./claude-desktop.md) | ✓ Complete |
 | Windsurf | [windsurf.md](./windsurf.md) | ✓ Complete |
+| Zed | [zed.md](./zed.md) | ✓ Complete |
 
 ## General Setup (All IDEs)
 
@@ -39,7 +40,7 @@ If you want to use a local Engram server instead of the hosted version:
 
 1. **Start Engram server**
    ```bash
-   cd /home/ismaeldev/Engram
+   cd /path/to/Engram
    source .venv/bin/activate
    python -m engram.cli serve --http
    ```
@@ -55,4 +56,4 @@ If your IDE doesn't detect Engram:
 - Verify Engram is running: `curl http://localhost:7474/`
 - Run `engram verify` to check configuration
 
-See [docs/TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for more help.
+See [docs/TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for more help.

--- a/docs/quickstart/zed.md
+++ b/docs/quickstart/zed.md
@@ -1,0 +1,75 @@
+# Zed Quickstart
+
+Zed supports MCP and can use Engram through `context_servers`.
+
+## Setup
+
+### Option 1: Auto-install (Recommended)
+
+```bash
+curl -fsSL https://engram-us.com/install | sh
+```
+
+### Option 2: Manual Setup
+
+Edit `~/.config/zed/settings.json` and add:
+
+```json
+{
+  "context_servers": {
+    "engram": {
+      "url": "https://mcp.engram.app/mcp"
+    }
+  }
+}
+```
+
+For local development:
+
+```json
+{
+  "context_servers": {
+    "engram": {
+      "url": "http://localhost:7474/mcp"
+    }
+  }
+}
+```
+
+Note: Zed uses `context_servers`, not `mcpServers`.
+
+2. Restart Zed.
+
+## First Time Setup
+
+1. Open a new chat in Zed
+2. Tell it: `"Set up Engram for my team"` to create a workspace
+3. Or: `"Join Engram with key ek_live_..."` to join an existing workspace
+
+## Usage
+
+Zed will automatically:
+
+- query team knowledge before working on code
+- commit discoveries to shared memory
+- detect conflicts between facts
+
+## Verification
+
+```bash
+engram verify
+```
+
+## Troubleshooting
+
+Check config:
+
+```bash
+cat ~/.config/zed/settings.json
+```
+
+Note: uses `context_servers`.
+
+Restart Zed after config changes.
+
+See [docs/TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for more help.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "numpy>=1.26.0",
     "pydantic>=2.0.0",
     "click>=8.0.0",
+    "questionary>=2.0.0",
     "uvicorn>=0.30.0",
     "starlette>=0.40.0",
     "aiohttp>=3.9.0",

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1258,7 +1258,7 @@ def setup(
     if not db_url:
         db_url = os.environ.get("ENGRAM_DB_URL", "")
 
-    backend_mode: str | None = None  # "cloud", "self-hosted", "local"
+    backend_mode: str | None = None  # "cloud", "postgres", "sqlite"
 
     if not db_url and not dry_run:
         try:
@@ -1270,26 +1270,26 @@ def setup(
             return
 
         choice = questionary.select(
-            "Which database would you like to use for storing team memory?",
+            "Which storage backend do you want to use?",
             choices=[
                 questionary.Choice(
-                    "Engram Cloud (Recommended)  —  Hosted backend, dashboard included, invite key"
-                    " required. Zero infrastructure setup.",
+                    "Engram Cloud (Recommended)\n     Hosted backend with dashboard included."
+                    " Requires an invite key. Zero infrastructure setup.",
                     value="cloud",
                 ),
                 questionary.Choice(
-                    "Self-hosted (PostgreSQL + pgvector)  —  Run your own server."
-                    " Full control, multi-machine.",
-                    value="self-hosted",
+                    "PostgreSQL (Self-hosted)\n     Run your own server with pgvector."
+                    " Full control, multi-machine support.",
+                    value="postgres",
                 ),
                 questionary.Choice(
-                    "Local only (SQLite)  —  No dashboard, no cross-agent sync."
-                    " Single machine, offline.",
-                    value="local",
+                    "SQLite (Local only)\n     No dashboard, no cross-agent sync."
+                    " Single machine, offline use only.",
+                    value="sqlite",
                 ),
                 questionary.Choice(
-                    "Chat about this",
-                    value="chat",
+                    "Help me choose",
+                    value="help",
                 ),
             ],
             use_arrow_keys=True,
@@ -1299,22 +1299,22 @@ def setup(
             # User hit Ctrl-C
             return
 
-        if choice == "chat":
+        if choice == "help":
             click.echo("")
             click.echo("Engram storage options:")
             click.echo("")
-            click.echo("  Engram Cloud  (Recommended for most teams)")
+            click.echo("  Engram Cloud  (Recommended)")
             click.echo("    • Hosted backend managed by the Engram team")
             click.echo("    • Dashboard and invite-key sharing included")
             click.echo("    • Join with:  engram join <invite-key>")
             click.echo("    • No servers to run or maintain")
             click.echo("")
-            click.echo("  Self-hosted PostgreSQL + pgvector")
+            click.echo("  PostgreSQL (Self-hosted)")
             click.echo("    • You control the database (Neon, Supabase, Railway, or your own)")
             click.echo("    • Required for on-prem / air-gapped environments")
             click.echo("    • Pass your URL:  engram setup --db-url postgres://...")
             click.echo("")
-            click.echo("  Local only (SQLite)")
+            click.echo("  SQLite (Local only)")
             click.echo("    • Zero config — works offline immediately")
             click.echo("    • Knowledge stays on this machine (no cross-agent sync)")
             click.echo("    • Run:  engram setup --local")
@@ -1325,12 +1325,12 @@ def setup(
 
         if backend_mode == "cloud":
             click.echo("")
-            click.echo("Engram Cloud backend selected.")
+            click.echo("Engram Cloud selected.")
             click.echo("  To join an existing workspace:  engram join <invite-key>")
             click.echo("  (Cloud workspaces are provisioned via invite key — no DB URL needed.)")
             return
 
-        if backend_mode == "self-hosted":
+        if backend_mode == "postgres":
             db_url = questionary.text(
                 "PostgreSQL connection URL:",
                 placeholder="postgres://user:password@host:5432/dbname",
@@ -1339,10 +1339,10 @@ def setup(
                 click.echo("❌ No database URL provided. Aborting.")
                 return
 
-        if backend_mode == "local":
+        if backend_mode == "sqlite":
             click.echo("")
-            click.echo("Local SQLite mode selected — no database URL needed.")
-            db_url = ""  # empty string = local mode throughout
+            click.echo("SQLite mode selected — no database URL needed.")
+            db_url = ""  # empty string = SQLite mode throughout
 
     # Step 2: Detect and configure MCP clients
     if skip_mcp:

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1254,15 +1254,95 @@ def setup(
     click.echo("\n=== Engram Setup ===")
     click.echo("Starting one-command setup...\n")
 
-    # Step 1: Get database URL
+    # Step 1: Choose backend (interactive when no --db-url given)
     if not db_url:
         db_url = os.environ.get("ENGRAM_DB_URL", "")
 
+    backend_mode: str | None = None  # "cloud", "self-hosted", "local"
+
     if not db_url and not dry_run:
-        click.echo("❌ Database URL required.")
-        click.echo("  Set ENGRAM_DB_URL env var or pass --db-url")
-        click.echo("  Get a free database at: neon.tech, supabase.com, or railway.app")
-        return
+        try:
+            import questionary
+        except ImportError:
+            click.echo("❌ questionary is required for interactive setup.")
+            click.echo("  Run: pip install questionary")
+            click.echo("  Or pass --db-url directly.")
+            return
+
+        choice = questionary.select(
+            "Which database would you like to use for storing team memory?",
+            choices=[
+                questionary.Choice(
+                    "Engram Cloud (Recommended)  —  Hosted backend, dashboard included, invite key"
+                    " required. Zero infrastructure setup.",
+                    value="cloud",
+                ),
+                questionary.Choice(
+                    "Self-hosted (PostgreSQL + pgvector)  —  Run your own server."
+                    " Full control, multi-machine.",
+                    value="self-hosted",
+                ),
+                questionary.Choice(
+                    "Local only (SQLite)  —  No dashboard, no cross-agent sync."
+                    " Single machine, offline.",
+                    value="local",
+                ),
+                questionary.Choice(
+                    "Chat about this",
+                    value="chat",
+                ),
+            ],
+            use_arrow_keys=True,
+        ).ask()
+
+        if choice is None:
+            # User hit Ctrl-C
+            return
+
+        if choice == "chat":
+            click.echo("")
+            click.echo("Engram storage options:")
+            click.echo("")
+            click.echo("  Engram Cloud  (Recommended for most teams)")
+            click.echo("    • Hosted backend managed by the Engram team")
+            click.echo("    • Dashboard and invite-key sharing included")
+            click.echo("    • Join with:  engram join <invite-key>")
+            click.echo("    • No servers to run or maintain")
+            click.echo("")
+            click.echo("  Self-hosted PostgreSQL + pgvector")
+            click.echo("    • You control the database (Neon, Supabase, Railway, or your own)")
+            click.echo("    • Required for on-prem / air-gapped environments")
+            click.echo("    • Pass your URL:  engram setup --db-url postgres://...")
+            click.echo("")
+            click.echo("  Local only (SQLite)")
+            click.echo("    • Zero config — works offline immediately")
+            click.echo("    • Knowledge stays on this machine (no cross-agent sync)")
+            click.echo("    • Run:  engram setup --local")
+            click.echo("")
+            return
+
+        backend_mode = choice
+
+        if backend_mode == "cloud":
+            click.echo("")
+            click.echo("Engram Cloud backend selected.")
+            click.echo("  To join an existing workspace:  engram join <invite-key>")
+            click.echo("  (Cloud workspaces are provisioned via invite key — no DB URL needed.)")
+            return
+
+        if backend_mode == "self-hosted":
+            db_url = questionary.text(
+                "PostgreSQL connection URL:",
+                placeholder="postgres://user:password@host:5432/dbname",
+            ).ask()
+            if not db_url:
+                click.echo("❌ No database URL provided. Aborting.")
+                return
+
+        if backend_mode == "local":
+            click.echo("")
+            click.echo("Local SQLite mode selected — no database URL needed.")
+            db_url = ""  # empty string = local mode throughout
 
     # Step 2: Detect and configure MCP clients
     if skip_mcp:
@@ -1306,8 +1386,11 @@ def setup(
 
             display_name = f"{hostname}-{int(time.time())}"
 
-        # Set env for initialization
-        os.environ["ENGRAM_DB_URL"] = db_url
+        # Set env for initialization (only when using PostgreSQL)
+        if db_url:
+            os.environ["ENGRAM_DB_URL"] = db_url
+        else:
+            os.environ.pop("ENGRAM_DB_URL", None)
 
         async def init_workspace():
             # Import server to get engram_init

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -26,7 +26,11 @@ _DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 _PATH_SYSTEM_HOME = Path.home()
 _PATH_APPDATA_DIR = Path(os.environ["APPDATA"]) if "APPDATA" in os.environ else None
 _PATH_APPSUPPORT_DIR = _PATH_SYSTEM_HOME / "Library" / "Application Support"  # Mac only
-_PATH_XDG_DIR = Path(os.environ["XDG_CONFIG_HOME"]) if "XDG_CONFIG_HOME" in os.environ else None
+_PATH_XDG_DIR = (
+    Path(os.environ["XDG_CONFIG_HOME"])
+    if "XDG_CONFIG_HOME" in os.environ
+    else _PATH_SYSTEM_HOME / ".config"
+)
 
 
 @click.group()
@@ -40,28 +44,46 @@ def main() -> None:
 # Read in the list of known client config locations and get their appropriate
 # config file (different systems have them in different places).
 
-_AGENT_CLIENTS = {}
+_MCP_CLIENTS = {}
 with open(os.path.join(_DATA_DIR, "cli-agent-clients.json"), "r") as file:
     agent_clients_json = json.load(file)
     for key in agent_clients_json.keys():
-        _AGENT_CLIENTS[key] = {}
+        _MCP_CLIENTS[key] = {}
         agent_config_path = agent_clients_json[key]["path"]
         if agent_clients_json[key]["config_path"]["appdata"] and _PATH_APPDATA_DIR:
-            _AGENT_CLIENTS[key]["path"] = Path(_PATH_APPDATA_DIR / agent_config_path)
+            _MCP_CLIENTS[key]["path"] = Path(_PATH_APPDATA_DIR / agent_config_path)
         elif agent_clients_json[key]["config_path"]["appsupport"] and _PATH_APPSUPPORT_DIR:
-            _AGENT_CLIENTS[key]["path"] = Path(_PATH_APPSUPPORT_DIR / agent_config_path)
+            _MCP_CLIENTS[key]["path"] = Path(_PATH_APPSUPPORT_DIR / agent_config_path)
         elif agent_clients_json[key]["config_path"]["xdg"] and _PATH_XDG_DIR:
-            _AGENT_CLIENTS[key]["path"] = Path(_PATH_XDG_DIR / agent_config_path)
+            _MCP_CLIENTS[key]["path"] = Path(_PATH_XDG_DIR / agent_config_path)
         elif agent_clients_json[key]["config_path"]["syshome"]:
-            _AGENT_CLIENTS[key]["path"] = Path(_PATH_SYSTEM_HOME / agent_config_path)
-        if "path" not in _AGENT_CLIENTS[key]:
-            _AGENT_CLIENTS[key]["path"] = Path("ValidPathNotFound")
-        _AGENT_CLIENTS[key]["key"] = agent_clients_json[key]["server_type_key"]
+            _MCP_CLIENTS[key]["path"] = Path(_PATH_SYSTEM_HOME / agent_config_path)
+        if "path" not in _MCP_CLIENTS[key]:
+            _MCP_CLIENTS[key]["path"] = Path("ValidPathNotFound")
+        _MCP_CLIENTS[key]["key"] = agent_clients_json[key]["server_type_key"]
 
 _ENGRAM_MCP_ENTRY = {
     "command": "uvx",
     "args": ["--from", "engram-team@latest", "engram", "serve"],
 }
+
+
+def _engram_mcp_entry_for_client(client_name: str) -> dict[str, object]:
+    import os
+
+    mcp_url = os.environ.get("ENGRAM_MCP_URL", "https://mcp.engram.app/mcp")
+
+    if client_name == "Windsurf":
+        return {"serverUrl": mcp_url}
+
+    if client_name == "Zed":
+        return {"url": mcp_url}
+
+    return {
+        "command": "uvx",
+        "args": ["--from", "engram-team@latest", "engram", "serve"],
+    }
+
 
 # ── Agent steering / instructions ────────────────────────────────────
 # After writing the MCP config, we also write agent instruction files so
@@ -159,7 +181,7 @@ def install(dry_run: bool) -> None:
     skipped = []
     steering_written = []
 
-    for client_name, info in _AGENT_CLIENTS.items():
+    for client_name, info in _MCP_CLIENTS.items():
         config_path: Path = info["path"]
         key: str = info["key"]
         fmt = info.get("format", "json")
@@ -211,7 +233,7 @@ def install(dry_run: bool) -> None:
                     steering_written.extend(_write_steering(client_name, dry_run))
                     continue
 
-                servers["engram"] = _ENGRAM_MCP_ENTRY
+                servers["engram"] = _engram_mcp_entry_for_client(client_name)
 
                 if not dry_run:
                     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1002,7 +1024,7 @@ def verify(verbose: bool) -> None:
     detected = []
     missing = []
 
-    for client_name, info in _AGENT_CLIENTS.items():
+    for client_name, info in _MCP_CLIENTS.items():
         config_path: Path = info["path"]
         try:
             if config_path.exists():
@@ -1351,7 +1373,7 @@ def setup(
         click.echo("[1/4] Detecting MCP clients...")
         # Reuse the install logic to detect clients
         added = []
-        for client_name, info in _AGENT_CLIENTS.items():
+        for client_name, info in _MCP_CLIENTS.items():
             config_path: Path = info["path"]
             if config_path.exists():
                 added.append(client_name)

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from engram.cli import main, _MCP_CLIENTS
+
+
+_REAL_HOME = Path.home()
+
+
+def _rebased_mcp_clients(home: Path) -> dict:
+    rebuilt = {}
+    for name, cfg in _MCP_CLIENTS.items():
+        new_cfg = dict(cfg)
+        try:
+            relative = cfg["path"].relative_to(_REAL_HOME)
+            new_cfg["path"] = home / relative
+        except ValueError:
+            pass
+        rebuilt[name] = new_cfg
+    return rebuilt
+
+
+def test_install_writes_windsurf_server_url(tmp_path, monkeypatch):
+    runner = CliRunner()
+    workspace_path = tmp_path / ".engram" / "workspace.json"
+
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://mcp.engram.app/mcp")
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+        patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+    ):
+        windsurf_config = tmp_path / ".codeium" / "windsurf" / "mcp_config.json"
+        windsurf_config.parent.mkdir(parents=True, exist_ok=True)
+        windsurf_config.write_text("{}")
+
+        result = runner.invoke(main, ["install"])
+
+        assert result.exit_code == 0
+
+        data = json.loads(windsurf_config.read_text())
+        assert "mcpServers" in data
+        assert "engram" in data["mcpServers"]
+        assert data["mcpServers"]["engram"] == {"serverUrl": "https://mcp.engram.app/mcp"}
+
+
+def test_install_writes_zed_context_server_url(tmp_path, monkeypatch):
+    runner = CliRunner()
+    workspace_path = tmp_path / ".engram" / "workspace.json"
+
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://mcp.engram.app/mcp")
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+        patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+    ):
+        zed_config = tmp_path / ".config" / "zed" / "settings.json"
+        zed_config.parent.mkdir(parents=True, exist_ok=True)
+        zed_config.write_text("{}")
+
+        result = runner.invoke(main, ["install"])
+
+        assert result.exit_code == 0
+
+        data = json.loads(zed_config.read_text())
+        assert "context_servers" in data
+        assert "engram" in data["context_servers"]
+        assert data["context_servers"]["engram"] == {"url": "https://mcp.engram.app/mcp"}

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 from click.testing import CliRunner
 
-from engram.cli import main, _AGENT_CLIENTS
+from engram.cli import main, _MCP_CLIENTS
 
 
 _REAL_HOME = Path.home()
@@ -15,7 +15,7 @@ _REAL_HOME = Path.home()
 def _rebased_agent_clients(home: Path) -> dict:
     """Rebuild _AGENT_CLIENTS with paths rooted under *home*."""
     rebuilt = {}
-    for name, cfg in _AGENT_CLIENTS.items():
+    for name, cfg in _MCP_CLIENTS.items():
         new_cfg = dict(cfg)
         try:
             relative = cfg["path"].relative_to(_REAL_HOME)
@@ -41,7 +41,7 @@ class TestVerifyCommand:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("engram.workspace.WORKSPACE_PATH", workspace_path),
-            patch("engram.cli._AGENT_CLIENTS", _rebased_agent_clients(tmp_path)),
+            patch("engram.cli._MCP_CLIENTS", _rebased_agent_clients(tmp_path)),
         ):
             yield tmp_path
 
@@ -159,6 +159,80 @@ class TestVerifyCommand:
         assert "✓" in result.output
         assert "Cursor" in result.output
 
+    def test_verify_detects_windsurf_config(self, cli_runner, temp_home):
+        """Test verify detects Engram in Windsurf MCP config."""
+        workspace_dir = temp_home / ".engram"
+        workspace_dir.mkdir(parents=True)
+        workspace_file = workspace_dir / "workspace.json"
+        workspace_file.write_text(
+            json.dumps(
+                {
+                    "engram_id": "ENG-TEST-1234",
+                    "db_url": "",
+                    "schema": "engram",
+                }
+            )
+        )
+
+        windsurf_dir = temp_home / ".codeium" / "windsurf"
+        windsurf_dir.mkdir(parents=True)
+        mcp_config = windsurf_dir / "mcp_config.json"
+        mcp_config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "engram": {
+                            "serverUrl": "https://mcp.engram.app/mcp",
+                        }
+                    }
+                }
+            )
+        )
+
+        with patch("pathlib.Path.home", return_value=temp_home):
+            result = cli_runner.invoke(main, ["verify"])
+
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert "Windsurf" in result.output
+
+    def test_verify_detects_zed_config(self, cli_runner, temp_home):
+        """Test verify detects Engram in Zed MCP config."""
+        workspace_dir = temp_home / ".engram"
+        workspace_dir.mkdir(parents=True)
+        workspace_file = workspace_dir / "workspace.json"
+        workspace_file.write_text(
+            json.dumps(
+                {
+                    "engram_id": "ENG-TEST-1234",
+                    "db_url": "",
+                    "schema": "engram",
+                }
+            )
+        )
+
+        zed_dir = temp_home / ".config" / "zed"
+        zed_dir.mkdir(parents=True)
+        settings_file = zed_dir / "settings.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "context_servers": {
+                        "engram": {
+                            "url": "https://mcp.engram.app/mcp",
+                        }
+                    }
+                }
+            )
+        )
+
+        with patch("pathlib.Path.home", return_value=temp_home):
+            result = cli_runner.invoke(main, ["verify"])
+
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert "Zed" in result.output
+
     def test_verify_verbose_flag(self, cli_runner, temp_home):
         """Test verify with --verbose flag shows additional details."""
         # Create workspace
@@ -237,7 +311,7 @@ class TestVerifyMCPClientDetection:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("engram.workspace.WORKSPACE_PATH", workspace_path),
-            patch("engram.cli._AGENT_CLIENTS", _rebased_agent_clients(tmp_path)),
+            patch("engram.cli._MCP_CLIENTS", _rebased_agent_clients(tmp_path)),
         ):
             yield tmp_path
 

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,7 @@ dependencies = [
     { name = "mcp" },
     { name = "numpy" },
     { name = "pydantic" },
+    { name = "questionary" },
     { name = "sentence-transformers" },
     { name = "starlette" },
     { name = "uvicorn" },
@@ -549,6 +550,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "questionary", specifier = ">=2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
     { name = "starlette", specifier = ">=0.40.0" },
@@ -1480,6 +1482,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1870,6 +1884,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -2606,6 +2632,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/f2/368268300fb8af33743508d738ef7bb4d56afdb46c6d9c0fa3dd515df171/uvicorn-0.43.0.tar.gz", hash = "sha256:ab1652d2fb23abf124f36ccc399828558880def222c3cb3d98d24021520dc6e8", size = 85686, upload-time = "2026-04-03T18:37:48.984Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/df/0cf5b0c451602748fdc7a702d4667f6e209bf96aa6e3160d754234445f2a/uvicorn-0.43.0-py3-none-any.whl", hash = "sha256:46fac64f487fd968cd999e5e49efbbe64bd231b5bd8b4a0b482a23ebce499620", size = 68591, upload-time = "2026-04-03T18:37:47.64Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Improves the documented and tested MCP setup path for Windsurf and Zed.

This PR makes Windsurf and Zed first-class IDE targets alongside Claude Code by aligning `engram install` with their client-specific MCP config shapes, adding explicit test coverage, and surfacing both IDEs in the docs and top-level README.

## What changed

- added client-specific install output for Windsurf and Zed in `engram install`
- added focused install tests for Windsurf and Zed config generation
- added explicit verify coverage for Windsurf and Zed MCP detection
- added `docs/quickstart/zed.md`
- added Zed to `docs/quickstart/README.md`
- added a first-class IDE targets section to the top-level README

## Why

The repo already had partial Windsurf/Zed support in the MCP client map, but the setup path was not fully documented, explicitly tested, or surfaced in the README. This PR makes that path clearer and more reliable.

## Validation

- `pytest -q tests/test_verify.py tests/test_cli_install.py`
- `ruff check .`
- manually verified Zed reads the MCP config and connects to a local Engram server

## Scope note

This PR covers the documented and tested MCP setup-path portion of #42.

For the Zed extension portion, I treated this as exploration only. Zed’s extension path appears to be Rust/WASM rather than Lua/WASM, so a native Engram sidebar remains follow-up work rather than part of this change.

For MCP quirks, this PR addresses the config/runtime differences surfaced during testing, including Zed `context_servers` handling and Windsurf’s client-specific config shape. Manual Zed validation reached MCP connection/backend confirmation, but full in-editor agent usage was not completed because Zed provider/account setup was still required.