### PR TITLE
fix: prioritize Engram Cloud in storage backend menu (issue #157)

### DIFF
--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -159,12 +159,14 @@ async def engram_status() -> dict[str, Any]:
         "status": "unconfigured",
         "next_prompt": (
             "Welcome to Engram — shared memory for your team's agents.\n\n"
-            "Do you have an Invite Key to join an existing workspace, "
-            "or are you setting up a new one?\n\n"
-            "If setting up a new workspace, you'll need a PostgreSQL database. "
-            "You can either:\n"
-            "  • Use your existing app database (Engram creates a separate 'engram' schema)\n"
-            "  • Get a free dedicated database at neon.tech, supabase.com, or railway.app"
+            "How would you like to get started?\n\n"
+            "1. **Engram Cloud** (Recommended) — Quickest setup. Get an invite key from your team admin, "
+            "or sign up at https://engram.us to create a workspace.\n"
+            "2. **PostgreSQL (Self-hosted)** — Use your own database. "
+            "You'll need a PostgreSQL connection URL ready.\n"
+            "3. **SQLite (Local only)** — For solo use or quick experiments. "
+            "No team features available.\n\n"
+            "Type the number of your choice, or paste your Invite Key to join an existing workspace."
         ),
     }
 

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -43,6 +43,8 @@ async def _seed_search_db(db_path, monkeypatch) -> None:
 def test_search_prints_formatted_results(monkeypatch, tmp_path):
     db_path = tmp_path / "engram.db"
     monkeypatch.setattr("engram.cli.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("engram.workspace.read_workspace", lambda: None)
+    monkeypatch.setenv("ENGRAM_DB_URL", "")
 
     asyncio.run(_seed_search_db(db_path, monkeypatch))
 
@@ -52,7 +54,7 @@ def test_search_prints_formatted_results(monkeypatch, tmp_path):
         ["search", "payments service", "--scope", "payments", "--limit", "1"],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
     assert 'Results for "payments service" (1):' in result.output
     assert (
         "[payments] Payments service retries failed webhooks with exponential backoff."
@@ -65,6 +67,8 @@ def test_search_prints_formatted_results(monkeypatch, tmp_path):
 def test_search_json_outputs_results(monkeypatch, tmp_path):
     db_path = tmp_path / "engram.db"
     monkeypatch.setattr("engram.cli.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("engram.workspace.read_workspace", lambda: None)
+    monkeypatch.setenv("ENGRAM_DB_URL", "")
 
     asyncio.run(_seed_search_db(db_path, monkeypatch))
 
@@ -87,6 +91,8 @@ def test_search_json_outputs_results(monkeypatch, tmp_path):
 def test_search_limit_applies(monkeypatch, tmp_path):
     db_path = tmp_path / "engram.db"
     monkeypatch.setattr("engram.cli.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("engram.workspace.read_workspace", lambda: None)
+    monkeypatch.setenv("ENGRAM_DB_URL", "")
 
     asyncio.run(_seed_search_db(db_path, monkeypatch))
 
@@ -103,6 +109,8 @@ def test_search_limit_applies(monkeypatch, tmp_path):
 def test_search_no_results_when_scope_has_no_facts(monkeypatch, tmp_path):
     db_path = tmp_path / "engram.db"
     monkeypatch.setattr("engram.cli.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("engram.workspace.read_workspace", lambda: None)
+    monkeypatch.setenv("ENGRAM_DB_URL", "")
 
     asyncio.run(_seed_search_db(db_path, monkeypatch))
 


### PR DESCRIPTION
## Summary
- Reorder onboarding options to prioritize Engram Cloud (Recommended)
- Add PostgreSQL (Self-hosted) as second option
- Add SQLite (Local only) as last option for solo use
- Fix test_cli_search.py to properly mock read_workspace

## Testing
- 300 tests passing

Closes #157