### PR TITLE
docs: add verification examples to all quickstart guides (issue #111)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Not sure where to start? These are always useful:
 - **Add test coverage** for an edge case you noticed
 - **Document a non-obvious behavior** in a code comment or the README
 - **Pick a roadmap item** from [README.md#roadmap](./README.md#roadmap) — comment on the issue before starting so we can align
+- **Add a quickstart guide** for your favorite IDE in `docs/quickstart/` — we already have Claude Code, Cursor, and VS Code, but need more
 
 ---
 

--- a/docs/quickstart/claude-code.md
+++ b/docs/quickstart/claude-code.md
@@ -58,6 +58,13 @@ Once configured, Claude Code will:
 engram verify
 ```
 
+**In your IDE:** Ask your agent: "Call engram_status and tell me what it returns."
+
+Expected output:
+```
+{"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
+```
+
 ## Troubleshooting
 
 - Check config: `cat ~/.claude.json`

--- a/docs/quickstart/cursor.md
+++ b/docs/quickstart/cursor.md
@@ -54,6 +54,13 @@ Once configured, Cursor's AI will:
 engram verify
 ```
 
+**In your IDE:** Ask your agent: "Call engram_status and tell me what it returns."
+
+Expected output:
+```
+{"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
+```
+
 ## Troubleshooting
 
 - Check config: `cat ~/.cursor/mcp.json`

--- a/docs/quickstart/vscode-copilot.md
+++ b/docs/quickstart/vscode-copilot.md
@@ -59,6 +59,13 @@ With Copilot + Engram, your AI assistant will:
 engram verify
 ```
 
+**In your IDE:** Ask your agent: "Call engram_status and tell me what it returns."
+
+Expected output:
+```
+{"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
+```
+
 ## Troubleshooting
 
 - Ensure GitHub Copilot is active

--- a/docs/quickstart/windsurf.md
+++ b/docs/quickstart/windsurf.md
@@ -56,6 +56,13 @@ Windsurf will automatically:
 engram verify
 ```
 
+**In your IDE:** Ask your agent: "Call engram_status and tell me what it returns."
+
+Expected output:
+```
+{"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
+```
+
 ## Troubleshooting
 
 - Check config: `cat ~/.codeium/windsurf/mcp_config.json`


### PR DESCRIPTION
## Summary
- Added verification examples to all quickstart guides (issue #111)
- Updated: cursor.md, claude-code.md, vscode-copilot.md, windsurf.md
- Added expected output example:
  ```
  {"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
  ```
- Helps users verify their setup is working correctly

## Quickstarts Updated
- Cursor
- Claude Code
- VS Code Copilot
- Windsurf

## Issues
- Resolves #111