### PR TITLE
fix: redirect to first page when last page becomes empty

### DIFF
--- a/src/engram/dashboard.py
+++ b/src/engram/dashboard.py
@@ -122,6 +122,12 @@ def build_dashboard_routes(storage: Storage, engine: Any = None) -> list[Route]:
                 scope=scope, fact_type=fact_type, as_of=as_of, limit=limit, offset=offset
             )
 
+        if not facts and offset > 0:
+            offset = 0
+            facts = await storage.get_current_facts_in_scope(
+                scope=scope, fact_type=fact_type, as_of=as_of, limit=limit, offset=0
+            )
+
         conflict_ids = await storage.get_open_conflict_fact_ids()
         return HTMLResponse(
             _render_facts_table(

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -241,17 +241,18 @@ class PostgresStorage(BaseStorage):
             )
         return [_row_to_dict(r) for r in rows]
 
-    async def fts_search(self, query: str, limit: int = 20) -> list[int]:
+    async def fts_search(self, query: str, limit: int = 20, offset: int = 0) -> list[int]:
         """Full-text search using tsvector. Returns a list of pseudo-rowids (not used in PG)."""
         async with self.acquire() as conn:
             rows = await conn.fetch(
                 "SELECT id, ts_rank(search_vector, plainto_tsquery('english', $1)) AS rank "
                 "FROM facts WHERE search_vector @@ plainto_tsquery('english', $1) "
                 "AND workspace_id = $2 AND valid_until IS NULL "
-                "ORDER BY rank DESC LIMIT $3",
+                "ORDER BY rank DESC LIMIT $3 OFFSET $4",
                 query,
                 self.workspace_id,
                 limit,
+                offset,
             )
         # Return ids as a list (PostgreSQL doesn't use integer rowids like SQLite)
         return [r["id"] for r in rows]

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -54,7 +54,7 @@ class BaseStorage(ABC):
     ) -> list[dict]: ...
 
     @abstractmethod
-    async def fts_search(self, query: str, limit: int = 20) -> list[int]: ...
+    async def fts_search(self, query: str, limit: int = 20, offset: int = 0) -> list[int]: ...
 
     @abstractmethod
     async def get_facts_by_rowids(self, rowids: list[int]) -> list[dict]: ...
@@ -581,11 +581,11 @@ class SQLiteStorage(BaseStorage):
         rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
-    async def fts_search(self, query: str, limit: int = 20) -> list[int]:
+    async def fts_search(self, query: str, limit: int = 20, offset: int = 0) -> list[int]:
         """FTS5 BM25 search. Returns rowids ordered by relevance."""
         cursor = await self.db.execute(
-            "SELECT rowid, rank FROM facts_fts WHERE facts_fts MATCH ? ORDER BY rank LIMIT ?",
-            (query, limit),
+            "SELECT rowid, rank FROM facts_fts WHERE facts_fts MATCH ? ORDER BY rank LIMIT ? OFFSET ?",
+            (query, limit, offset),
         )
         rows = await cursor.fetchall()
         return [r["rowid"] for r in rows]


### PR DESCRIPTION
## Summary
- When a user is on a later page and all subsequent facts are deleted, redirect to the first page instead of showing an empty table.

Closes #105