### PR TITLE
Improve commit response with conflict risk estimation and detection visibility.

### DIFF
--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -391,6 +391,8 @@ class EngramEngine:
             "committed_at": now,
             "duplicate": False,
             "conflicts_detected": False,  # detection is async
+            "conflict_check_queued": durability == "durable",
+            "conflict_risk" : self._estimate_conflict_risk(content, scope),
             "memory_op": operation,
             "supersedes_fact_id": supersedes_fact_id,
             "durability": durability,
@@ -418,6 +420,30 @@ class EngramEngine:
             pass
 
         return result
+    
+    # Adding helper function estimate_conflict_risk.
+    def _estimate_conflict_risk(self, content: str, scope: str) -> str:
+        """
+        Lightweight approximation to estimate likelihood of conflict
+        before async detection completes.
+        """
+
+        text = content.lower()
+
+        risk_keywords = [
+            "always", "never", "must", "guaranteed",
+            "limit", "rate", "timeout", "threshold",
+            "retry", "should", "fail", "error"
+        ]
+
+        if any(char.isdigit() for char in text):
+            return "high"
+
+        if any (word in text for word in risk_keywords):
+            return "medium"
+        
+        
+        return "low"
 
     # ── engram_query ─────────────────────────────────────────────────
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -41,6 +41,13 @@ async def test_commit_returns_proactive_suggestions_for_rate_limit(engine: Engra
     assert len(result["suggestions"]) <= 2
     assert any("retry" in s.lower() for s in result["suggestions"])
 
+def test_conflict_risk_estimation():
+    engine = EngramEngine(storage=None)  # storage not needed for this test
+
+    assert engine._estimate_conflict_risk("Rate limit is 1000", "api") == "high"
+    assert engine._estimate_conflict_risk("System should retry requests", "api") == "medium"
+    assert engine._estimate_conflict_risk("UI color is blue", "ui") == "low"
+
 
 @pytest.mark.asyncio
 async def test_commit_dedup(engine: EngramEngine):


### PR DESCRIPTION
While reviewing the commit pipeline, I noticed that conflict detection is fully asynchronous, but the commit response does not expose any signal indicating that a conflict check has been queued or the likelihood of a future conflict.

This can make it difficult for agents to reason about the reliability of newly committed facts in real-time.

This PR introduces:

conflict_check_queued to indicate async detection is in progress
conflict_risk — a lightweight heuristic to estimate potential conflict likelihood based on content

This improves observability and allows agents to make more informed decisions before conflict detection completes.

The implementation is intentionally simple and non-blocking, preserving the performance characteristics of the commit path.