### PR TITLE
Add engram doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ engram config show        # Display configuration
 engram config set <key>   # Update configuration
 engram tail               # Live stream of workspace commits
 engram verify             # Verify installation
+engram doctor             # Diagnose setup issues
 engram completion <shell> # Install shell tab completion
 ```
 

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -940,87 +940,151 @@ def info() -> None:
 # ── engram verify ────────────────────────────────────────────────────
 
 
-@main.command()
-@click.option("--verbose", "-v", is_flag=True, help="Show details for all checks.")
-def verify(verbose: bool) -> None:
-    """Verify Engram installation and configuration.
+_QUICKSTART_URL = "https://github.com/Agentscreator/Engram/blob/main/docs/quickstart/README.md"
+_TROUBLESHOOTING_URL = "https://github.com/Agentscreator/Engram/blob/main/docs/TROUBLESHOOTING.md"
+_NLI_MODEL_NAME = "cross-encoder/nli-MiniLM2-L6-H768"
 
-    Runs a focused checklist and prints a clear pass/fail for each:
-    ✓ workspace.json exists and is valid
-    ✓ Backend is reachable (team mode)
-    ✓ MCP config written to at least one IDE
-    ✓ NLI model files present (if using conflict detection)
-    """
+
+def _mcp_health_url(mcp_url: str) -> str:
+    if mcp_url.endswith("/mcp"):
+        return mcp_url[: -len("/mcp")] + "/health"
+    return mcp_url
+
+
+def _nli_cache_paths() -> list[Path]:
+    model_dir = Path.home() / ".cache" / "huggingface" / "hub"
+    return [
+        model_dir / "models--cross-encoder--nli-MiniLM2-L6-H768",
+        Path.home() / ".cache" / "sentence_transformers" / "cross-encoder" / "nli-MiniLM2-L6-H768",
+    ]
+
+
+async def _check_storage_connectivity(ws: object | None) -> tuple[bool, str]:
+    if ws is not None and getattr(ws, "db_url", ""):
+        from engram.postgres_storage import PostgresStorage
+
+        storage = PostgresStorage(
+            db_url=getattr(ws, "db_url"),
+            workspace_id=getattr(ws, "engram_id", "local"),
+            schema=getattr(ws, "schema", "engram"),
+        )
+    else:
+        from engram.storage import SQLiteStorage
+
+        storage = SQLiteStorage(db_path=DEFAULT_DB_PATH, workspace_id="local")
+
+    try:
+        await storage.connect()
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    finally:
+        try:
+            await storage.close()
+        except Exception:
+            pass
+
+    return True, ""
+
+
+def _run_diagnostics(command_name: str, verbose: bool, load_nli: bool) -> bool:
+    """Run installation diagnostics shared by `verify` and `doctor`."""
     from engram.workspace import WORKSPACE_PATH, read_workspace
-    import json
-    import urllib.request
     import urllib.error
-    import os
+    import urllib.request
 
     all_passed = True
     verbose = verbose or os.environ.get("ENGRAM_VERIFY_VERBOSE") == "1"
+    ws = None
 
-    # Check 1: workspace.json exists and is valid JSON
-    click.echo("\n[1/4] Checking workspace configuration...")
+    click.echo(f"\nEngram {command_name}: checking installation health")
+
+    # Check 1: workspace.json exists and is semantically readable.
+    click.echo("\n[1/5] Checking workspace configuration...")
     if not WORKSPACE_PATH.exists():
         click.echo("  ✗ ~/.engram/workspace.json not found")
         click.echo("    → Run: engram init   (or: engram join <key>)")
-        click.echo(
-            "    → Docs: https://github.com/Agentscreator/Engram/blob/main/docs/QUICKSTART.md"
-        )
+        click.echo(f"    → Docs: {_QUICKSTART_URL}")
         all_passed = False
     else:
         try:
-            data = json.loads(WORKSPACE_PATH.read_text())
-            ws = read_workspace()
-            mode = "team" if ws and ws.db_url else "local"
-            click.echo(f"  ✓ workspace.json exists ({mode} mode)")
-            if verbose:
-                click.echo(f"    - engram_id: {ws.engram_id if ws else 'N/A'}")
-                click.echo(f"    - schema: {ws.schema if ws else 'N/A'}")
-                click.echo(f"    - anonymous_mode: {ws.anonymous_mode if ws else 'N/A'}")
-        except json.JSONDecodeError as e:
-            click.echo(f"  ✗ workspace.json is invalid JSON: {e}")
+            json.loads(WORKSPACE_PATH.read_text())
+        except json.JSONDecodeError as exc:
+            click.echo(f"  ✗ workspace.json is invalid JSON: {exc}")
             click.echo("    → Delete and re-run: rm ~/.engram/workspace.json && engram init")
             all_passed = False
+        else:
+            ws = read_workspace()
+            if ws is None:
+                click.echo("  ✗ workspace.json could not be parsed as an Engram workspace")
+                click.echo("    → Run: engram config show")
+                click.echo(f"    → Docs: {_TROUBLESHOOTING_URL}")
+                all_passed = False
+            else:
+                mode = "team" if ws.db_url else "local"
+                click.echo(f"  ✓ workspace.json exists and is valid ({mode} mode)")
+                if verbose:
+                    click.echo(f"    - engram_id: {ws.engram_id}")
+                    click.echo(f"    - schema: {ws.schema}")
+                    click.echo(f"    - anonymous_mode: {ws.anonymous_mode}")
 
-    # Check 2: Backend is reachable (team mode only)
-    click.echo("\n[2/4] Checking backend connectivity...")
-    ws = read_workspace()
-    if ws and ws.db_url:
-        # For team mode, check if we can reach the MCP endpoint
-        # The MCP URL pattern is derived from db_url or uses default
-        mcp_url = os.environ.get("ENGRAM_MCP_URL", "https://mcp.engram.app/mcp")
-
-        # Try a simple HEAD request to check connectivity
-        try:
-            req = urllib.request.Request(
-                mcp_url.replace("/mcp", "/health") if "/mcp" in mcp_url else mcp_url, method="HEAD"
+    # Check 2: storage backend can connect.
+    click.echo("\n[2/5] Checking database connectivity...")
+    if WORKSPACE_PATH.exists() and ws is None:
+        click.echo("  ○ Skipped until workspace configuration is fixed")
+    else:
+        ok, error = asyncio.run(_check_storage_connectivity(ws))
+        if ok:
+            storage_label = "PostgreSQL" if ws and ws.db_url else "SQLite"
+            click.echo(f"  ✓ {storage_label} storage connected")
+            if verbose and not (ws and ws.db_url):
+                click.echo(f"    - path: {DEFAULT_DB_PATH}")
+        else:
+            click.echo("  ✗ Storage connection failed")
+            click.echo(f"    - Error: {error}")
+            click.echo("    → For local mode, check ~/.engram permissions and disk space")
+            click.echo(
+                "    → For team mode, verify ENGRAM_DB_URL or rejoin with a fresh invite key"
             )
+            click.echo(f"    → Docs: {_TROUBLESHOOTING_URL}")
+            all_passed = False
+
+    # Check 3: MCP server module can load and optional HTTP endpoint responds.
+    click.echo("\n[3/5] Checking MCP server reachability...")
+    try:
+        from engram.server import mcp
+
+        if mcp is None:
+            raise RuntimeError("FastMCP server object is missing")
+        click.echo("  ✓ MCP server module loads")
+    except Exception as exc:
+        click.echo("  ✗ MCP server failed to load")
+        click.echo(f"    - Error: {type(exc).__name__}: {exc}")
+        click.echo("    → Reinstall Engram or check Python dependency installation")
+        click.echo(f"    → Docs: {_TROUBLESHOOTING_URL}")
+        all_passed = False
+
+    mcp_url = os.environ.get("ENGRAM_MCP_URL", "")
+    if mcp_url:
+        try:
+            req = urllib.request.Request(_mcp_health_url(mcp_url), method="HEAD")
             with urllib.request.urlopen(req, timeout=5) as resp:
                 if resp.status < 400:
-                    click.echo(f"  ✓ Backend reachable at {mcp_url}")
+                    click.echo(f"  ✓ MCP HTTP endpoint reachable at {mcp_url}")
                 else:
-                    click.echo(f"  ✗ Backend returned status {resp.status}")
-                    all_passed = False
-        except urllib.error.URLError as e:
-            # Non-critical: backend might not have /health endpoint
-            click.echo("  ⚠ Could not reach health endpoint (non-critical)")
+                    click.echo(f"  ⚠ MCP HTTP endpoint returned status {resp.status}")
+        except urllib.error.URLError as exc:
+            click.echo("  ⚠ Could not reach MCP HTTP endpoint")
             if verbose:
                 click.echo(f"    - URL: {mcp_url}")
-                click.echo(f"    - Error: {e.reason}")
-                click.echo("    - Note: Backend connectivity will be verified by your IDE")
-        except Exception as e:
-            click.echo(f"  ⚠ Could not verify backend ({type(e).__name__}: {e})")
-            if verbose:
-                click.echo("    - This is normal if you're offline or the backend is busy")
-    else:
-        click.echo("  ○ Team mode not configured (local SQLite mode)")
-        if verbose:
-            click.echo("    - For team features: engram init or engram join <key>")
+                click.echo(f"    - Error: {exc.reason}")
+            click.echo(
+                "    → If you use a remote MCP URL, verify ENGRAM_MCP_URL and network access"
+            )
+    elif verbose:
+        click.echo("    - ENGRAM_MCP_URL not set; stdio MCP mode will be used by default")
 
-    # Check 3: MCP config in at least one IDE
-    click.echo("\n[3/4] Checking MCP configuration in IDEs...")
+    # Check 4: MCP config in at least one IDE.
+    click.echo("\n[4/5] Checking MCP configuration in IDEs...")
     detected = []
     missing = []
 
@@ -1031,7 +1095,6 @@ def verify(verbose: bool) -> None:
                 data = json.loads(config_path.read_text())
                 key = info["key"]
 
-                # Navigate nested keys (e.g., "mcpServers" or "mcp")
                 keys = key.split(".")
                 current = data
                 found = True
@@ -1057,56 +1120,90 @@ def verify(verbose: bool) -> None:
     else:
         click.echo("  ✗ Engram not found in any IDE MCP config")
         click.echo("    → Run: engram install")
+        click.echo(f"    → Docs: {_QUICKSTART_URL}")
         all_passed = False
 
     if missing and verbose:
         click.echo("\n  Other detected IDEs (Engram not configured):")
-        for client_name in missing[:5]:  # Limit verbose output
+        for client_name in missing[:5]:
             click.echo(f"    - ○ {client_name}")
         if len(missing) > 5:
             click.echo(f"    - ... and {len(missing) - 5} more")
 
-    # Check 4: NLI model files present
-    click.echo("\n[4/4] Checking NLI model files...")
-    model_dir = Path.home() / ".cache" / "huggingface" / "hub"
-    nli_model_path = model_dir / "models--cross-encoder--nli-MiniLM2-L6-H768"
+    # Check 5: NLI model cache or opt-in full load.
+    click.echo("\n[5/5] Checking NLI model...")
+    if load_nli:
+        try:
+            from sentence_transformers import CrossEncoder
 
-    # Check in common locations
-    possible_paths = [
-        nli_model_path,
-        Path.home() / ".cache" / "sentence_transformers" / "cross-encoder" / "nli-MiniLM2-L6-H768",
-    ]
-
-    found_model = False
-    for path in possible_paths:
-        if path.exists():
-            click.echo(f"  ✓ NLI model found at {path}")
-            found_model = True
-            break
-
-    if not found_model:
-        click.echo("  ⚠ NLI model not cached (will download on first conflict detection)")
-        if verbose:
-            click.echo("    - Model: cross-encoder/nli-MiniLM2-L6-H768")
-            click.echo("    - Will be downloaded automatically when needed")
+            CrossEncoder(_NLI_MODEL_NAME)
+            click.echo(f"  ✓ NLI model loaded: {_NLI_MODEL_NAME}")
+        except Exception as exc:
+            click.echo("  ✗ NLI model failed to load")
+            click.echo(f"    - Error: {type(exc).__name__}: {exc}")
             click.echo(
-                "    - This is optional - Engram works without it (Tier 1 detection disabled)"
+                "    → Install optional model dependencies or allow first-run model download"
             )
+            click.echo(f"    → Docs: {_TROUBLESHOOTING_URL}")
+            all_passed = False
+    else:
+        found_path = next((path for path in _nli_cache_paths() if path.exists()), None)
+        if found_path:
+            click.echo(f"  ✓ NLI model cache found at {found_path}")
+        else:
+            click.echo("  ⚠ NLI model not cached (will download on first conflict detection)")
+            click.echo("    → Run: engram doctor --load-nli to verify the model can load now")
+            if verbose:
+                click.echo(f"    - Model: {_NLI_MODEL_NAME}")
+                click.echo("    - This is optional; deterministic conflict checks still work")
 
-    # Summary
     click.echo("\n" + "=" * 50)
     if all_passed:
-        click.echo("✓ All checks passed! Engram is ready to use.")
+        click.echo("✓ All checks passed! All required checks passed. Engram is ready to use.")
         click.echo("\nNext steps:")
         click.echo("  1. Restart your IDE")
         click.echo("  2. Ask your agent: 'Set up Engram for my team'")
-        click.echo("  3. Run 'engram verify' anytime to re-check")
+        click.echo(f"  3. Run 'engram {command_name}' anytime to re-check")
     else:
-        click.echo("✗ Some checks failed. Fix the issues above and run 'engram verify' again.")
         click.echo(
-            "\nFor help: https://github.com/Agentscreator/Engram/blob/main/docs/TROUBLESHOOTING.md"
+            f"✗ Some checks failed. Fix the issues above and run 'engram {command_name}' again."
         )
+        click.echo(f"\nFor help: {_TROUBLESHOOTING_URL}")
     click.echo("=" * 50 + "\n")
+
+    return all_passed
+
+
+@main.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show details for all checks.")
+@click.option(
+    "--load-nli",
+    is_flag=True,
+    help="Attempt to load the NLI model instead of only checking the local cache.",
+)
+def verify(verbose: bool, load_nli: bool) -> None:
+    """Verify Engram installation and configuration.
+
+    Runs a focused checklist and prints a clear pass/fail for each:
+    ✓ workspace.json exists and is valid
+    ✓ Storage backend can connect
+    ✓ MCP server module loads
+    ✓ MCP config written to at least one IDE
+    ✓ NLI model cache present, or full model loads with --load-nli
+    """
+    _run_diagnostics("verify", verbose=verbose, load_nli=load_nli)
+
+
+@main.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show details for all checks.")
+@click.option(
+    "--load-nli",
+    is_flag=True,
+    help="Attempt to load the NLI model instead of only checking the local cache.",
+)
+def doctor(verbose: bool, load_nli: bool) -> None:
+    """Diagnose a broken Engram setup and print actionable fixes."""
+    _run_diagnostics("doctor", verbose=verbose, load_nli=load_nli)
 
 
 # ── engram re-embed ───────────────────────────────────────────────────

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -70,6 +70,6 @@ Validates that contradictory facts are surfaced as conflicts, that severity clas
 | `test_cli_install.py` | `engram install` IDE config injection |
 | `test_cli_search.py` | `engram search` CLI command |
 | `test_cli_tail.py` | `engram tail` live-tail command |
-| `test_verify.py` | `engram verify` schema and connectivity checks |
+| `test_verify.py` | `engram verify` / `engram doctor` schema, connectivity, MCP, and NLI checks |
 | `test_install_sh.py` | Shell installer script correctness |
 | `test_rediscovery_experiment.py` | Rediscovery / re-embedding experiment harness |

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,7 +1,9 @@
-"""Tests for the engram verify command."""
+"""Tests for the engram diagnostics commands."""
 
 import json
 import pytest
+import sys
+import types
 from pathlib import Path
 from unittest.mock import patch
 from click.testing import CliRunner
@@ -41,6 +43,7 @@ class TestVerifyCommand:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+            patch("engram.cli.DEFAULT_DB_PATH", tmp_path / ".engram" / "knowledge.db"),
             patch("engram.cli._MCP_CLIENTS", _rebased_agent_clients(tmp_path)),
         ):
             yield tmp_path
@@ -81,6 +84,7 @@ class TestVerifyCommand:
         assert "✓" in result.output
         assert "workspace.json exists" in result.output
         assert "local" in result.output
+        assert "SQLite storage connected" in result.output
 
     def test_verify_workspace_invalid_json(self, cli_runner, temp_home):
         """Test verify with invalid JSON in workspace.json."""
@@ -257,6 +261,101 @@ class TestVerifyCommand:
         # Verbose should show engram_id and schema details
         assert "engram_id:" in result.output
         assert "anonymous_mode:" in result.output
+
+    def test_doctor_runs_shared_diagnostics(self, cli_runner, temp_home):
+        """Test doctor uses the same diagnostics surface as verify."""
+        workspace_dir = temp_home / ".engram"
+        workspace_dir.mkdir(parents=True)
+        workspace_file = workspace_dir / "workspace.json"
+        workspace_file.write_text(
+            json.dumps(
+                {
+                    "engram_id": "ENG-TEST-1234",
+                    "db_url": "",
+                    "schema": "engram",
+                }
+            )
+        )
+
+        cursor_dir = temp_home / ".cursor"
+        cursor_dir.mkdir(parents=True)
+        mcp_config = cursor_dir / "mcp.json"
+        mcp_config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "engram": {
+                            "command": "uvx",
+                            "args": ["--from", "engram-team@latest", "engram", "serve"],
+                        }
+                    }
+                }
+            )
+        )
+
+        result = cli_runner.invoke(main, ["doctor"])
+
+        assert result.exit_code == 0
+        assert "Engram doctor" in result.output
+        assert "SQLite storage connected" in result.output
+        assert "MCP server module loads" in result.output
+        assert "All required checks passed" in result.output
+
+    def test_doctor_reports_storage_failure(self, cli_runner, temp_home, monkeypatch):
+        """Test doctor surfaces actionable storage failures."""
+        workspace_dir = temp_home / ".engram"
+        workspace_dir.mkdir(parents=True)
+        workspace_file = workspace_dir / "workspace.json"
+        workspace_file.write_text(
+            json.dumps(
+                {
+                    "engram_id": "ENG-TEST-1234",
+                    "db_url": "",
+                    "schema": "engram",
+                }
+            )
+        )
+
+        async def fake_storage_check(_ws):
+            return False, "PermissionError: denied"
+
+        monkeypatch.setattr("engram.cli._check_storage_connectivity", fake_storage_check)
+
+        result = cli_runner.invoke(main, ["doctor"])
+
+        assert result.exit_code == 0
+        assert "Storage connection failed" in result.output
+        assert "PermissionError: denied" in result.output
+        assert "TROUBLESHOOTING.md" in result.output
+
+    def test_doctor_load_nli_success(self, cli_runner, temp_home, monkeypatch):
+        """Test --load-nli verifies the model can be constructed."""
+        workspace_dir = temp_home / ".engram"
+        workspace_dir.mkdir(parents=True)
+        workspace_file = workspace_dir / "workspace.json"
+        workspace_file.write_text(
+            json.dumps(
+                {
+                    "engram_id": "ENG-TEST-1234",
+                    "db_url": "",
+                    "schema": "engram",
+                }
+            )
+        )
+
+        fake_module = types.ModuleType("sentence_transformers")
+
+        class FakeCrossEncoder:
+            def __init__(self, model_name):
+                self.model_name = model_name
+
+        fake_module.CrossEncoder = FakeCrossEncoder
+        monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
+
+        result = cli_runner.invoke(main, ["doctor", "--load-nli"])
+
+        assert result.exit_code == 0
+        assert "NLI model loaded" in result.output
 
     def test_verify_summary_success(self, cli_runner, temp_home):
         """Test that success summary is shown when all checks pass."""


### PR DESCRIPTION
## Summary

Adds `engram doctor` as a self-diagnosis command for setup and runtime issues.

This reuses and extends the existing diagnostics path instead of creating a separate implementation. It keeps `engram verify` working for backward compatibility while introducing a clearer user-facing command for troubleshooting broken setup paths.

## What changed

- added shared diagnostics logic in `src/engram/cli.py` used by both `engram verify` and `engram doctor`
- added `engram doctor`
- kept `engram verify` backward-compatible
- added checks for:
  - workspace configuration validity
  - SQLite / PostgreSQL storage connectivity
  - MCP server module load
  - optional MCP HTTP health
  - IDE MCP config presence
  - NLI cache readiness or explicit `--load-nli`
- improved actionable remediation output with fix links
- updated existing diagnostics coverage in `tests/test_verify.py`
- updated command documentation in `README.md`
- updated test inventory in `tests/TESTS.md`

## Why

Users who hit setup issues need a way to self-diagnose broken paths instead of guessing. This makes setup failures easier to understand and fix, which improves onboarding and reduces silent misconfiguration.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pytest -q`
- `python -m engram.cli --help | grep -E "doctor|verify"`

## Notes

`engram doctor` is implemented by refactoring and extending the existing verification path rather than duplicating logic in a separate code path.

`engram verify` remains supported for backward compatibility.