### PR TITLE
GDPR_Erasure_Tooling_N01

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,12 @@ All source lives under `src/engram/`.
 
 | Module | Purpose |
 |--------|---------|
-| `server.py` | MCP server (FastMCP) with 14 tools — the I/O layer |
-| `engine.py` | Core memory engine: commit pipeline, conflict detection (5-tier async) |
+| `server.py` | MCP server (FastMCP) with 15 tools — the I/O layer |
+| `engine.py` | Core memory engine: commit pipeline, conflict detection (5-tier async), GDPR erasure |
 | `storage.py` | SQLite backend (async, WAL mode, FTS5) |
 | `postgres_storage.py` | PostgreSQL backend (pgvector, tsvector, TIMESTAMPTZ) |
-| `schema.py` | Database schema definitions and migrations (currently v7) |
-| `cli.py` | CLI commands: `serve`, `verify`, `install`, `config`, `completion`, `re-embed` |
+| `schema.py` | Database schema definitions and migrations (currently v10) |
+| `cli.py` | CLI commands: `serve`, `verify`, `install`, `config`, `gdpr`, `completion`, `re-embed` |
 | `rest.py` | REST API for non-MCP clients (`/api/commit`, `/api/query`, etc.) |
 | `dashboard.py` | HTML dashboard with HTMX at `/dashboard` |
 | `workspace.py` | Workspace configuration (team ID, db_url, schema) |
@@ -50,7 +50,7 @@ All source lives under `src/engram/`.
 
 ## Schema Version Invariant
 
-- Database schema version is tracked in `src/engram/schema.py` (currently **v7**)
+- Database schema version is tracked in `src/engram/schema.py` (currently **v10**)
 - When adding new tables or columns, increment `SCHEMA_VERSION` and add a migration entry
 - Document the migration path in `docs/MIGRATION_SCHEMA.md`
 
@@ -60,7 +60,7 @@ All source lives under `src/engram/`.
 2. **Run existing tests** — `pytest tests/ -x` to ensure nothing breaks
 3. **Check `docs/MIGRATION_SCHEMA.md`** — If changes affect the database, document the migration path
 
-## MCP Tools (14 total)
+## MCP Tools (15 total)
 
 **Onboarding:**
 - `engram_status` — Check workspace state, guide setup
@@ -84,6 +84,9 @@ All source lives under `src/engram/`.
 - `engram_expiring` — Facts with TTL approaching expiry
 - `engram_bulk_dismiss` — Batch dismiss conflicts
 - `engram_export` — Export data (JSON, Markdown)
+
+**Compliance:**
+- `engram_gdpr_erase` — GDPR right-to-erasure for an agent (founder only; soft or hard mode)
 
 ## Rules
 
@@ -109,3 +112,4 @@ All source lives under `src/engram/`.
 - `HIRING.md` — Paid contract opportunities ($125-185/hour)
 - `docs/IMPLEMENTATION.md` — Architecture and phase delivery plan
 - `docs/MIGRATION_SCHEMA.md` — Database migration guide
+- `docs/PRIVACY_ARCHITECTURE.md` — GDPR erasure, anonymous mode, zero-knowledge design

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ queuing, and 72-hour auto-escalation).
 `resolve()`, `batch_commit()`, `get_stats()`, `record_feedback()`,
 `get_timeline()`, `get_agents()`, `get_fact()`, `list_facts()`,
 `export_workspace()`, `get_lineage()`, `get_expiring_facts()`,
-`bulk_dismiss()`.
+`bulk_dismiss()`, `gdpr_erase_agent()`.
 
 **Must not:** access the database directly — all persistence goes through a
 `BaseStorage` implementation. Must not import or depend on any transport layer
@@ -77,7 +77,8 @@ guidance (tool descriptions that steer agent behavior) lives here.
 
 **Public interface:** The MCP tool set — `engram_status`, `engram_init`,
 `engram_join`, `engram_reset_invite_key`, `engram_commit`, `engram_query`,
-`engram_conflicts`, `engram_resolve`, `engram_promote`, and others.
+`engram_conflicts`, `engram_resolve`, `engram_promote`, `engram_gdpr_erase`,
+and others.
 
 **Must not:** contain business logic. No conflict detection, no query scoring,
 no direct database calls. If a tool needs new behavior, add it to `engine.py`
@@ -94,7 +95,8 @@ embedding storage.
 
 **Public interface:** `BaseStorage` (ABC), `SQLiteStorage`. Key methods:
 `insert_fact()`, `query_facts()`, `get_conflicts()`, `resolve_conflict()`,
-`upsert_agent()`, `get_workspace_stats()`, plus ~40 more CRUD operations.
+`upsert_agent()`, `get_workspace_stats()`, `gdpr_soft_erase_agent()`,
+`gdpr_hard_erase_agent()`, plus ~40 more CRUD operations.
 
 **Must not:** contain business logic or orchestration. Storage executes queries
 and returns rows — it does not decide *what* to store or *when* to detect
@@ -119,9 +121,10 @@ must be added to `BaseStorage` first, then implemented in both backends.
 ### schema.py — DDL and Migrations
 
 Contains all database DDL (`SCHEMA_SQL` for SQLite, `POSTGRES_SCHEMA_SQL` for
-PostgreSQL) and incremental migration definitions (v2 through v7). Tables:
-`workspaces`, `facts`, `facts_ephemeral`, `conflicts`, `claims`,
-`invite_keys`, `agents`, `query_log`, plus FTS5 virtual tables and triggers.
+PostgreSQL) and incremental migration definitions (v2 through v10). Tables:
+`workspaces`, `facts`, `conflicts`, `invite_keys`, `agents`, `audit_log`,
+`scopes`, `webhooks`, plus FTS5 virtual tables and triggers (including the
+`facts_au` update trigger added in v10 for GDPR hard-erase FTS consistency).
 
 **Public interface:** `SCHEMA_SQL`, `POSTGRES_SCHEMA_SQL`, `MIGRATIONS`,
 `SCHEMA_VERSION`.
@@ -285,6 +288,50 @@ Queued asynchronously by the engine's suggestion background worker. Requires
 **Must not:** resolve conflicts — it only *suggests*. Resolution authority
 remains with `engine.py` (via `resolve()`). Must not be called synchronously in
 the commit or query hot path.
+
+---
+
+### GDPR Subject-Erasure Path
+
+When a workspace creator calls `engram_gdpr_erase` (MCP), `engram gdpr erase`
+(CLI), or `POST /api/gdpr/erase` (REST), the following happens:
+
+```
+Caller (MCP / REST / CLI)
+    │
+    │  creator-only gate (read_workspace().is_creator)
+    ▼
+EngramEngine.gdpr_erase_agent(agent_id, mode="soft"|"hard")
+    │
+    ├── mode="soft"
+    │       └── storage.gdpr_soft_erase_agent(agent_id)
+    │               UPDATE facts  SET engineer='[redacted]', provenance=NULL
+    │               UPDATE conflicts  (scrub explanation / suggestion fields)
+    │               UPDATE agents     SET engineer='[redacted]'
+    │               UPDATE audit_log  (clear agent_id)
+    │               COMMIT (atomic)
+    │
+    └── mode="hard"
+            └── storage.gdpr_hard_erase_agent(agent_id)
+                    UPDATE facts  (replace content, null embedding/keywords,
+                                   close valid_until)          ← facts_au trigger
+                                                                  keeps FTS in sync
+                    UPDATE conflicts  (dismiss open, scrub resolved)
+                    UPDATE agents / DELETE scope_permissions / UPDATE scopes
+                    UPDATE audit_log  (clear agent_id + fact_id)
+                    COMMIT (atomic)
+    │
+    └── _audit("gdpr_erase", ...)  — records counts, mode; no agent PII
+```
+
+**Conflict cascade rules:**
+- Open conflicts referencing an erased fact: status → `dismissed`,
+  `resolution_type → 'gdpr_erasure'`, all free-text fields scrubbed.
+- Already-resolved conflicts: only free-text fields scrubbed
+  (`explanation`, `resolution`, suggestions).
+- `suggested_winning_fact_id` is nulled if it pointed at an erased fact.
+
+For full operational guidance see `docs/PRIVACY_ARCHITECTURE.md` §"GDPR Subject Erasure".
 
 ---
 

--- a/docs/MIGRATION_SCHEMA.md
+++ b/docs/MIGRATION_SCHEMA.md
@@ -334,8 +334,50 @@ If you encounter issues:
 3. Check tables: `\dt engram.*` in psql
 4. Open an issue with logs and error messages
 
+## Schema Version History
+
+| Version | What changed |
+|---------|-------------|
+| v2 | Conflict suggestion columns |
+| v3 | `memory_op`, `supersedes_fact_id` on facts |
+| v4 | Multi-tenancy (`workspace_id`), `workspaces` and `invite_keys` tables |
+| v5 | `corroborating_agents` on facts |
+| v6 | `durability`, `query_hits` on facts |
+| v7 | `key_generation` on workspaces |
+| v8 | `webhooks`, `webhook_deliveries`, `resolution_rules`, `scopes`, `audit_log` |
+| v9 | `display_name`, `description` on workspaces |
+| v10 | SQLite `facts_au` AFTER UPDATE trigger (FTS5 consistency for GDPR hard-erase) |
+
+## Schema v10 — GDPR FTS Update Trigger
+
+**New installs:** the `facts_au` trigger is included in `SCHEMA_SQL` automatically.
+
+**Existing SQLite installs:** the trigger is created during the v10 migration that
+runs automatically on next `connect()`.
+
+**PostgreSQL installs:** no migration needed.  The `search_vector` column is a
+`GENERATED ALWAYS AS ... STORED` tsvector, so any `UPDATE` to `content` or
+`keywords` automatically refreshes the GIN index.
+
+The trigger is required by the **GDPR hard-erase path** (`engram gdpr erase --mode hard`)
+which replaces fact `content` and clears `keywords` in a bulk `UPDATE`.  Without
+the trigger, FTS5 shadow tables would retain old content and erased facts would
+still appear in full-text search results.
+
+```sql
+-- Added by v10 migration (SQLite only)
+CREATE TRIGGER IF NOT EXISTS facts_au
+    AFTER UPDATE OF content, scope, keywords ON facts BEGIN
+        INSERT INTO facts_fts(facts_fts, rowid, content, scope, keywords)
+        VALUES ('delete', old.rowid, old.content, old.scope, old.keywords);
+        INSERT INTO facts_fts(rowid, content, scope, keywords)
+        VALUES (new.rowid, new.content, new.scope, new.keywords);
+    END;
+```
+
 ## Related Documentation
 
+- [PRIVACY_ARCHITECTURE.md](./PRIVACY_ARCHITECTURE.md) - GDPR erasure workflow
 - [DATABASE_SECURITY.md](./DATABASE_SECURITY.md) - Security features
 - [IMPLEMENTATION.md](./IMPLEMENTATION.md) - Technical details
 - [README.md](../README.md) - Quick start guide

--- a/docs/PRIVACY_ARCHITECTURE.md
+++ b/docs/PRIVACY_ARCHITECTURE.md
@@ -230,6 +230,102 @@ CREATE TABLE engram.facts (
 );
 ```
 
+## GDPR Subject Erasure
+
+`anonymous_mode` prevents future attribution but does **not** erase historical
+data already stored.  For EU customers, or any workspace subject to GDPR /
+right-to-erasure requirements, Engram provides a dedicated erasure pipeline.
+
+### When to use subject erasure
+
+| Situation | Recommendation |
+|-----------|---------------|
+| Team member leaves, future commits should be anonymous | `anonymous_mode = true` is sufficient |
+| Legal right-to-erasure request received | Use `engram_gdpr_erase` / `engram gdpr erase` |
+| Data breach: agent content must be destroyed | Hard erase + delete backups |
+
+### Soft erase
+
+Redacts the `engineer` (free-text name) and `provenance` fields on every fact
+version committed by the agent.  Conflict `explanation` and suggestion strings
+are also scrubbed to prevent indirect leakage.  Fact content is preserved, so
+the team's knowledge base remains coherent.  The agent's entry in the registry
+is also anonymised.
+
+```
+Before: engineer = "alice@example.com"  content = "Cache TTL must be 300s"
+After:  engineer = "[redacted]"          content = "Cache TTL must be 300s"  ← unchanged
+```
+
+### Hard erase
+
+Everything in soft mode, plus:
+
+- Fact `content` is replaced with a per-row placeholder (`[gdpr:erased:<id>]`)
+  that cannot be retrieved by content or semantic search.
+- `keywords`, `entities`, and `embedding` are cleared.
+- The validity window (`valid_until`) is closed on all still-current facts,
+  effectively retiring them from the live knowledge base.
+- Every open conflict that references an erased fact is dismissed with
+  `resolution_type = 'gdpr_erasure'`.  Resolved conflicts have their free-text
+  fields scrubbed.
+- `scope_permissions` rows for the agent are deleted.
+- `scopes.owner_agent_id` is nulled where it pointed to this agent.
+- `audit_log` rows are scrubbed: `agent_id` cleared on actor rows, `fact_id`
+  cleared on rows tied to erased facts.
+
+```
+Before: content = "Cache TTL must be 300s"   valid_until = NULL
+After:  content = "[gdpr:erased:abc123]"     valid_until = "2026-04-12T..."
+```
+
+### How to trigger
+
+**Via MCP tool (agent-driven):**
+```
+Call engram_gdpr_erase with agent_id="<id>" and mode="soft" or mode="hard"
+```
+
+**Via CLI:**
+```bash
+engram gdpr erase --agent-id agent-abc123 --mode soft
+engram gdpr erase --agent-id agent-abc123 --mode hard --yes   # skip confirmation
+```
+
+**Via REST (HTTP mode):**
+```bash
+curl -X POST http://localhost:7474/api/gdpr/erase \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id": "agent-abc123", "mode": "soft"}'
+```
+
+All three entry points are restricted to the **workspace creator** (`is_creator = true`
+in `~/.engram/workspace.json`).  A `PermissionError` / 403 is returned for all others.
+
+### What is preserved after erasure
+
+| Field | Soft | Hard |
+|-------|------|------|
+| Fact ID (for referential integrity) | ✅ kept | ✅ kept |
+| Fact content | ✅ kept | ❌ replaced |
+| Fact `valid_until` | ✅ unchanged | ❌ closed |
+| `engineer` field | ❌ `[redacted]` | ❌ `[redacted]` |
+| `embedding` | ✅ kept | ❌ nulled |
+| `keywords`, `entities` | ✅ kept | ❌ nulled |
+| Conflict rows | ✅ kept | ❌ open→dismissed |
+| Conflict text fields | ❌ scrubbed | ❌ scrubbed |
+| `audit_log` actor rows | ❌ agent_id nulled | ❌ agent_id nulled |
+
+### Operator checklist before hard erase
+
+1. **Backup first.** Hard erase is irreversible.
+2. Identify the correct `agent_id` via `engram_agents` or `GET /api/agents`.
+3. Confirm workspace creator status (`is_creator: true` in `~/.engram/workspace.json`).
+4. Run soft erase first in staging/test if possible.
+5. Keep an internal record of the erasure event (time, requester, agent erased)
+   for your own compliance audit trail — Engram's audit log entry is also
+   scrubbed during erasure.
+
 ## Related Documentation
 
 - [DATABASE_SECURITY.md](./DATABASE_SECURITY.md) - Database configuration and isolation

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1683,5 +1683,99 @@ def export_cmd(format: str, output: str | None, scope: str | None) -> None:
         click.echo(f"Error: {e}", err=True)
 
 
+# ── engram gdpr ──────────────────────────────────────────────────────
+
+
+@main.group()
+def gdpr() -> None:
+    """GDPR / legal subject-erasure commands (workspace creator only)."""
+    pass
+
+
+@gdpr.command("erase")
+@click.option("--agent-id", required=True, help="Agent ID whose data should be erased.")
+@click.option(
+    "--mode",
+    type=click.Choice(["soft", "hard"]),
+    required=True,
+    help=(
+        "soft: redact engineer name and provenance only, fact content preserved. "
+        "hard: wipe fact content, close validity windows, cascade-dismiss conflicts."
+    ),
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip interactive confirmation (for non-interactive / scripted use).",
+)
+def gdpr_erase(agent_id: str, mode: str, yes: bool) -> None:
+    """Erase personal data for an agent (GDPR right-to-erasure / right-to-be-forgotten).
+
+    Requires the local workspace to be initialised as a creator workspace.
+    Hard erase is irreversible — always back up your database first.
+    """
+    import asyncio
+
+    if not yes:
+        action = (
+            "SOFT erase (redact attribution fields)"
+            if mode == "soft"
+            else "HARD erase (wipe content, close validity, dismiss conflicts — IRREVERSIBLE)"
+        )
+        click.echo(f"\nAbout to perform: {action}")
+        click.echo(f"Agent ID : {agent_id}")
+        click.confirm("Proceed?", abort=True)
+
+    async def _run() -> None:
+        from engram.engine import EngramEngine
+        from engram.workspace import read_workspace
+
+        ws = read_workspace()
+        if ws is None:
+            raise click.ClickException("No workspace configured. Run 'engram setup' first.")
+        if not ws.is_creator:
+            raise click.ClickException(
+                "GDPR erasure is restricted to the workspace creator."
+            )
+
+        if ws.db_url.startswith("postgres"):
+            from engram.postgres_storage import PostgresStorage
+
+            storage = PostgresStorage(ws.db_url, workspace_id=ws.engram_id, schema=ws.schema)
+        else:
+            from engram.storage import SQLiteStorage
+
+            storage = SQLiteStorage(workspace_id=ws.engram_id)
+
+        await storage.connect()
+        try:
+            engine = EngramEngine(storage)
+            result = await engine.gdpr_erase_agent(agent_id, mode, actor="cli")  # type: ignore[arg-type]
+        finally:
+            await storage.close()
+
+        stats = result["stats"]
+        click.echo(f"\nGDPR {mode} erase complete for agent: {agent_id}")
+        click.echo(f"  Facts updated          : {stats['facts_updated']}")
+        if mode == "hard":
+            click.echo(f"  Conflicts closed       : {stats['conflicts_closed']}")
+        click.echo(f"  Conflicts scrubbed     : {stats['conflicts_scrubbed']}")
+        click.echo(f"  Agents updated         : {stats['agents_updated']}")
+        if mode == "hard":
+            click.echo(f"  Scope permissions del. : {stats['scope_permissions_deleted']}")
+            click.echo(f"  Scopes updated         : {stats['scopes_updated']}")
+        click.echo(f"  Audit rows scrubbed    : {stats['audit_rows_scrubbed']}")
+
+    try:
+        asyncio.run(_run())
+    except click.ClickException:
+        raise
+    except PermissionError as exc:
+        raise click.ClickException(str(exc))
+    except Exception as exc:
+        raise click.ClickException(f"Erasure failed: {exc}")
+
+
 if __name__ == "__main__":
     main()

--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -2380,6 +2380,75 @@ class EngramEngine:
             limit=limit,
         )
 
+    # ── GDPR subject erasure ─────────────────────────────────────────
+
+    async def gdpr_erase_agent(
+        self,
+        agent_id: str,
+        mode: Literal["soft", "hard"],
+        *,
+        actor: str | None = None,
+    ) -> dict[str, Any]:
+        """Erase all personal data for a given agent from this workspace.
+
+        Gated to workspace creators only.  Use ``mode='soft'`` to redact
+        attribution fields while keeping fact content intact, or
+        ``mode='hard'`` to also wipe fact content, close validity windows,
+        and cascade-dismiss related open conflicts.
+
+        Args:
+            agent_id: The agent whose data should be erased.
+            mode: ``'soft'`` or ``'hard'``.
+            actor: Identity of the person triggering the erasure (for audit).
+
+        Returns:
+            A summary dict with counts of affected rows per table.
+
+        Raises:
+            ValueError: If agent_id is empty or mode is invalid.
+            PermissionError: If the caller is not a workspace creator.
+        """
+        if not agent_id or not agent_id.strip():
+            raise ValueError("agent_id must be a non-empty string.")
+        if mode not in ("soft", "hard"):
+            raise ValueError("mode must be 'soft' or 'hard'.")
+
+        # Creator-only gate — read local workspace.json
+        try:
+            from engram.workspace import read_workspace
+
+            ws = read_workspace()
+            if ws is None or not ws.is_creator:
+                raise PermissionError(
+                    "GDPR erasure is restricted to the workspace creator. "
+                    "Only the founder who ran engram_init may perform this operation."
+                )
+        except PermissionError:
+            raise
+        except Exception as exc:
+            raise PermissionError(
+                f"Unable to verify workspace creator status: {exc}"
+            ) from exc
+
+        if mode == "soft":
+            stats = await self.storage.gdpr_soft_erase_agent(agent_id)
+        else:
+            stats = await self.storage.gdpr_hard_erase_agent(agent_id)
+
+        await self._audit(
+            "gdpr_erase",
+            agent_id=None,  # do not store the erased agent_id in the audit trail
+            extra=f'{{"mode":"{mode}","facts_updated":{stats["facts_updated"]},'
+                  f'"conflicts_closed":{stats["conflicts_closed"]},'
+                  f'"actor":"{actor or "unknown"}"}}',
+        )
+
+        return {
+            "erased_agent_id": agent_id,
+            "mode": mode,
+            "stats": stats,
+        }
+
 
 def _content_hash(content: str) -> str:
     """SHA-256 of lowercased, whitespace-normalized content."""

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -1105,6 +1105,177 @@ class PostgresStorage(BaseStorage):
             )
         return [_row_to_dict(r) for r in rows]
 
+    # ── GDPR subject-erasure ─────────────────────────────────────────
+
+    async def gdpr_soft_erase_agent(self, agent_id: str) -> dict[str, int]:
+        """Soft-erase: redact engineer/provenance on all facts; scrub related rows.
+
+        All statements run inside a single asyncpg transaction.
+        """
+        wid = self.workspace_id
+        async with self.acquire() as conn:
+            async with conn.transaction():
+                r = await conn.execute(
+                    "UPDATE facts SET engineer = '[redacted]', provenance = NULL "
+                    "WHERE agent_id = $1 AND workspace_id = $2",
+                    agent_id, wid,
+                )
+                facts_updated = int(r.split()[-1])
+
+                r = await conn.execute(
+                    """UPDATE conflicts
+                       SET explanation            = '[redacted]',
+                           suggested_resolution   = NULL,
+                           suggested_resolution_type = NULL,
+                           suggestion_reasoning   = NULL
+                       WHERE workspace_id = $1
+                         AND (fact_a_id IN (SELECT id FROM facts WHERE agent_id = $2 AND workspace_id = $1)
+                              OR fact_b_id IN (SELECT id FROM facts WHERE agent_id = $2 AND workspace_id = $1))""",
+                    wid, agent_id,
+                )
+                conflicts_scrubbed = int(r.split()[-1])
+
+                r = await conn.execute(
+                    "UPDATE agents SET engineer = '[redacted]', label = NULL "
+                    "WHERE agent_id = $1 AND workspace_id = $2",
+                    agent_id, wid,
+                )
+                agents_updated = int(r.split()[-1])
+
+                r = await conn.execute(
+                    "UPDATE audit_log SET agent_id = NULL, extra = '{}' "
+                    "WHERE agent_id = $1 AND workspace_id = $2",
+                    agent_id, wid,
+                )
+                audit_rows_scrubbed = int(r.split()[-1])
+
+        return {
+            "facts_updated": facts_updated,
+            "conflicts_scrubbed": conflicts_scrubbed,
+            "agents_updated": agents_updated,
+            "conflicts_closed": 0,
+            "scope_permissions_deleted": 0,
+            "scopes_updated": 0,
+            "audit_rows_scrubbed": audit_rows_scrubbed,
+        }
+
+    async def gdpr_hard_erase_agent(self, agent_id: str) -> dict[str, int]:
+        """Hard-erase: wipe fact payload, retire current versions, cascade conflicts.
+
+        Postgres search_vector is a GENERATED column so UPDATE on content/keywords
+        automatically refreshes the GIN index — no extra trigger is needed.
+        All statements run inside a single asyncpg transaction.
+        """
+        now = _now_ts()
+        wid = self.workspace_id
+        async with self.acquire() as conn:
+            async with conn.transaction():
+                r = await conn.execute(
+                    """UPDATE facts
+                       SET content      = '[gdpr:erased:' || id || ']',
+                           content_hash = 'gdpr:erased:' || id,
+                           engineer     = '[redacted]',
+                           provenance   = NULL,
+                           keywords     = NULL,
+                           entities     = NULL,
+                           embedding    = NULL,
+                           valid_until  = COALESCE(valid_until, $1)
+                       WHERE agent_id = $2 AND workspace_id = $3""",
+                    now, agent_id, wid,
+                )
+                facts_updated = int(r.split()[-1])
+
+                r = await conn.execute(
+                    """UPDATE conflicts
+                       SET status                    = 'dismissed',
+                           resolution_type           = 'gdpr_erasure',
+                           resolution                = '[gdpr:erased]',
+                           resolved_at               = $1,
+                           resolved_by               = 'gdpr',
+                           explanation               = '[redacted]',
+                           suggested_resolution      = NULL,
+                           suggested_resolution_type = NULL,
+                           suggested_winning_fact_id = NULL,
+                           suggestion_reasoning      = NULL
+                       WHERE workspace_id = $2
+                         AND status = 'open'
+                         AND (fact_a_id IN (SELECT id FROM facts WHERE agent_id = $3 AND workspace_id = $2)
+                              OR fact_b_id IN (SELECT id FROM facts WHERE agent_id = $3 AND workspace_id = $2))""",
+                    now, wid, agent_id,
+                )
+                conflicts_closed = int(r.split()[-1])
+
+                r = await conn.execute(
+                    """UPDATE conflicts
+                       SET explanation               = '[redacted]',
+                           resolution                = '[redacted]',
+                           suggested_resolution      = NULL,
+                           suggested_resolution_type = NULL,
+                           suggestion_reasoning      = NULL
+                       WHERE workspace_id = $1
+                         AND status != 'open'
+                         AND (fact_a_id IN (SELECT id FROM facts WHERE agent_id = $2 AND workspace_id = $1)
+                              OR fact_b_id IN (SELECT id FROM facts WHERE agent_id = $2 AND workspace_id = $1))""",
+                    wid, agent_id,
+                )
+                conflicts_scrubbed = int(r.split()[-1])
+
+                await conn.execute(
+                    """UPDATE conflicts
+                       SET suggested_winning_fact_id = NULL
+                       WHERE workspace_id = $1
+                         AND suggested_winning_fact_id IN
+                             (SELECT id FROM facts WHERE agent_id = $2 AND workspace_id = $1)""",
+                    wid, agent_id,
+                )
+
+                r = await conn.execute(
+                    "UPDATE agents SET engineer = '[redacted]', label = NULL "
+                    "WHERE agent_id = $1 AND workspace_id = $2",
+                    agent_id, wid,
+                )
+                agents_updated = int(r.split()[-1])
+
+                r = await conn.execute(
+                    "DELETE FROM scope_permissions WHERE agent_id = $1",
+                    agent_id,
+                )
+                scope_permissions_deleted = int(r.split()[-1])
+
+                r = await conn.execute(
+                    "UPDATE scopes SET owner_agent_id = NULL "
+                    "WHERE owner_agent_id = $1 AND workspace_id = $2",
+                    agent_id, wid,
+                )
+                scopes_updated = int(r.split()[-1])
+
+                r = await conn.execute(
+                    "UPDATE audit_log SET agent_id = NULL, extra = '{}' "
+                    "WHERE agent_id = $1 AND workspace_id = $2",
+                    agent_id, wid,
+                )
+                audit_actor = int(r.split()[-1])
+
+                r = await conn.execute(
+                    """UPDATE audit_log
+                       SET fact_id = NULL, extra = '{}'
+                       WHERE workspace_id = $1
+                         AND fact_id IN
+                             (SELECT id FROM facts WHERE agent_id = $2 AND workspace_id = $1)""",
+                    wid, agent_id,
+                )
+                audit_fact = int(r.split()[-1])
+
+        return {
+            "facts_updated": facts_updated,
+            "conflicts_closed": conflicts_closed,
+            "conflicts_scrubbed": conflicts_scrubbed,
+            "agents_updated": agents_updated,
+            "scope_permissions_deleted": scope_permissions_deleted,
+            "scopes_updated": scopes_updated,
+            "audit_rows_scrubbed": audit_actor + audit_fact,
+        }
+
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/src/engram/rest.py
+++ b/src/engram/rest.py
@@ -846,6 +846,43 @@ def build_rest_routes(
             return _error(str(exc), status=500)
         return JSONResponse(result)
 
+    # ── GDPR erasure ──────────────────────────────────────────────────
+
+    async def api_gdpr_erase(request: Request) -> JSONResponse:
+        """POST /api/gdpr/erase — erase all personal data for an agent.
+
+        Request body: {"agent_id": "...", "mode": "soft"|"hard"}
+        Restricted to workspace creator.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            return _error("Request body must be valid JSON.")
+
+        agent_id = body.get("agent_id", "")
+        mode = body.get("mode", "soft")
+
+        if not agent_id:
+            return _error("agent_id is required.")
+        if mode not in ("soft", "hard"):
+            return _error("mode must be 'soft' or 'hard'.")
+
+        try:
+            result = await engine.gdpr_erase_agent(
+                agent_id=agent_id,
+                mode=mode,
+                actor=body.get("actor"),
+            )
+        except PermissionError as exc:
+            return _error(str(exc), status=403)
+        except ValueError as exc:
+            return _error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("REST /api/gdpr/erase error")
+            return _error(str(exc), status=500)
+
+        return JSONResponse(result)
+
     return [
         Route("/api/commit", api_commit, methods=["POST"]),
         Route("/api/query", api_query, methods=["POST"]),
@@ -884,4 +921,6 @@ def build_rest_routes(
         Route("/api/diff/{fact_id_a}/{fact_id_b}", api_diff, methods=["GET"]),
         # Audit
         Route("/api/audit", api_audit, methods=["GET"]),
+        # GDPR
+        Route("/api/gdpr/erase", api_gdpr_erase, methods=["POST"]),
     ]

--- a/src/engram/schema.py
+++ b/src/engram/schema.py
@@ -5,12 +5,16 @@ Schema version 4 adds:
 - invite_keys table (for join flow)
 - workspace_id column on facts, conflicts, agents (multi-tenancy)
 
+Schema version 10 adds:
+- facts_au trigger for SQLite FTS5 consistency on content/keywords updates
+  (required by the GDPR subject-erasure hard-erase path)
+
 Two schemas are maintained:
 - SCHEMA_SQL: SQLite (local mode, aiosqlite)
 - POSTGRES_SCHEMA_SQL: PostgreSQL (team mode, asyncpg)
 """
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 # Incremental ALTER TABLE migrations keyed by target version.
 MIGRATIONS: dict[int, list[str]] = {
@@ -119,6 +123,21 @@ MIGRATIONS: dict[int, list[str]] = {
         "ALTER TABLE workspaces ADD COLUMN display_name TEXT NOT NULL DEFAULT ''",
         "ALTER TABLE workspaces ADD COLUMN description TEXT NOT NULL DEFAULT ''",
     ],
+    10: [
+        # SQLite FTS5 update trigger for GDPR hard-erase path.
+        # facts_fts uses external-content mode (content=facts), so UPDATE
+        # statements on content/keywords do not automatically refresh the index.
+        # This trigger keeps the shadow table consistent by deleting the old
+        # entry and re-inserting the new one in a single statement group.
+        # Postgres uses a GENERATED tsvector column, so no migration is needed there.
+        """CREATE TRIGGER IF NOT EXISTS facts_au
+           AFTER UPDATE OF content, scope, keywords ON facts BEGIN
+               INSERT INTO facts_fts(facts_fts, rowid, content, scope, keywords)
+               VALUES ('delete', old.rowid, old.content, old.scope, old.keywords);
+               INSERT INTO facts_fts(rowid, content, scope, keywords)
+               VALUES (new.rowid, new.content, new.scope, new.keywords);
+           END""",
+    ],
 }
 
 # ── SQLite schema (local mode) ───────────────────────────────────────
@@ -179,6 +198,15 @@ CREATE TRIGGER IF NOT EXISTS facts_ad AFTER DELETE ON facts BEGIN
     INSERT INTO facts_fts(facts_fts, rowid, content, scope, keywords)
     VALUES ('delete', old.rowid, old.content, old.scope, old.keywords);
 END;
+
+-- Keep FTS5 shadow table in sync when content/keywords are updated (e.g. GDPR erasure).
+CREATE TRIGGER IF NOT EXISTS facts_au
+    AFTER UPDATE OF content, scope, keywords ON facts BEGIN
+        INSERT INTO facts_fts(facts_fts, rowid, content, scope, keywords)
+        VALUES ('delete', old.rowid, old.content, old.scope, old.keywords);
+        INSERT INTO facts_fts(rowid, content, scope, keywords)
+        VALUES (new.rowid, new.content, new.scope, new.keywords);
+    END;
 
 -- Conflict tracking
 CREATE TABLE IF NOT EXISTS conflicts (

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -1366,6 +1366,71 @@ async def engram_export(
         return {"error": str(exc)}
 
 
+# ── engram_gdpr_erase ─────────────────────────────────────────────────
+
+
+@mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": True})
+async def engram_gdpr_erase(
+    agent_id: str,
+    mode: Literal["soft", "hard"] = "soft",
+) -> dict[str, Any]:
+    """Erase personal data for an agent (GDPR right-to-erasure). Founder only.
+
+    Use this when a team member leaves and you receive a legal erasure request
+    for an EU / GDPR-covered subject.  Always back up your database before
+    running a hard erase.
+
+    **soft** — Redacts the engineer name and provenance field on every fact
+    version committed by this agent. Conflict explanation strings are scrubbed
+    to avoid leaking the name indirectly. Fact content remains intact so the
+    team's knowledge base stays coherent.
+
+    **hard** — Everything in soft mode, plus: fact content is replaced with a
+    per-row placeholder, keywords, entities, and the embedding vector are
+    cleared (so the fact cannot be retrieved by content or semantic search),
+    the validity window is closed on all still-current facts (retiring them),
+    and every open conflict that references an erased fact is dismissed with
+    resolution_type='gdpr_erasure'. This mode is irreversible.
+
+    In both modes the following are also scrubbed:
+    - agents table: engineer name and label.
+    - scope_permissions (hard only): rows for this agent are deleted.
+    - scopes: owner_agent_id nulled where it matched.
+    - audit_log: agent_id and associated fact_id references are cleared.
+
+    IMPORTANT: This operation is restricted to the workspace creator (founder).
+    IMPORTANT: The anonymous_mode workspace setting is not sufficient for GDPR
+    compliance — it prevents future attribution but does not erase historical
+    data.  Use this tool for legal right-to-erasure requests instead.
+
+    Parameters:
+    - agent_id: The exact agent ID to erase (find it via engram_agents).
+    - mode: 'soft' (redact attribution only) or 'hard' (wipe content too).
+
+    Returns: {erased_agent_id, mode, stats: {facts_updated, conflicts_closed, ...}}
+    """
+    engine = get_engine()
+    from engram.workspace import read_workspace as _rw
+
+    _ws = _rw()
+    if not _ws:
+        return {"error": "Workspace not initialized. Run engram_init first."}
+
+    try:
+        return await engine.gdpr_erase_agent(
+            agent_id=agent_id,
+            mode=mode,
+            actor=None,
+        )
+    except PermissionError as exc:
+        return {"error": str(exc), "status": "forbidden"}
+    except ValueError as exc:
+        return {"error": str(exc), "status": "invalid_request"}
+    except Exception as exc:
+        logger.exception("engram_gdpr_erase error")
+        return {"error": str(exc)}
+
+
 # ── engram_create_webhook ─────────────────────────────────────────────
 
 

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -368,6 +368,40 @@ class BaseStorage(ABC):
         limit: int = 100,
     ) -> list[dict]: ...
 
+    # ── GDPR subject-erasure methods ──────────────────────────────────
+
+    @abstractmethod
+    async def gdpr_soft_erase_agent(self, agent_id: str) -> dict[str, int]:
+        """Soft-erase all PII for agent_id in this workspace.
+
+        Redacts engineer name and provenance on every fact version, scrubs
+        free-text fields on related conflicts, anonymises the agents-table
+        row, and scrubs the audit log.  Fact content and validity are
+        preserved so the knowledge base remains coherent.
+
+        Returns a dict of affected-row counts keyed by table/operation.
+        """
+        ...
+
+    @abstractmethod
+    async def gdpr_hard_erase_agent(self, agent_id: str) -> dict[str, int]:
+        """Hard-erase all data for agent_id in this workspace.
+
+        In addition to the soft-erase redaction this:
+        - Replaces fact content with a per-row placeholder and clears
+          keywords, entities, and the embedding vector so the fact can
+          never be retrieved by content or semantic search.
+        - Closes the validity window on all current facts (retires them).
+        - Dismisses every open conflict that references an erased fact,
+          marking it with resolution_type='gdpr_erasure'.
+        - Scrubs free-text on already-resolved conflicts too.
+        - Deletes scope-permission rows for the agent.
+        - Nulls owner_agent_id on any scopes owned by the agent.
+
+        Returns a dict of affected-row counts keyed by table/operation.
+        """
+        ...
+
 
 class SQLiteStorage(BaseStorage):
     """Async SQLite storage with WAL mode and FTS5."""
@@ -1721,6 +1755,193 @@ class SQLiteStorage(BaseStorage):
         )
         rows = await cursor.fetchall()
         return [dict(r) for r in rows]
+
+    # ── GDPR subject-erasure ─────────────────────────────────────────
+
+    async def gdpr_soft_erase_agent(self, agent_id: str) -> dict[str, int]:
+        """Soft-erase: redact engineer/provenance on all facts; scrub related rows.
+
+        All six statements run before a single commit so the operation is
+        atomic from the perspective of any concurrent reader.
+        """
+        wid = self.workspace_id
+
+        # 1. Redact engineer name and provenance on every fact version.
+        c = await self.db.execute(
+            "UPDATE facts SET engineer = '[redacted]', provenance = NULL "
+            "WHERE agent_id = ? AND workspace_id = ?",
+            (agent_id, wid),
+        )
+        facts_updated = c.rowcount
+
+        # 2. Scrub free-text conflict columns for conflicts that reference
+        #    this agent's facts (open and resolved alike — both can embed
+        #    the engineer name in auto-generated explanation strings).
+        c = await self.db.execute(
+            """UPDATE conflicts
+               SET explanation            = '[redacted]',
+                   suggested_resolution   = NULL,
+                   suggested_resolution_type = NULL,
+                   suggestion_reasoning   = NULL
+               WHERE workspace_id = ?
+                 AND (fact_a_id IN (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?)
+                      OR fact_b_id IN (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?))""",
+            (wid, agent_id, wid, agent_id, wid),
+        )
+        conflicts_scrubbed = c.rowcount
+
+        # 3. Redact engineer name on the agents-registry row.
+        c = await self.db.execute(
+            "UPDATE agents SET engineer = '[redacted]', label = NULL "
+            "WHERE agent_id = ? AND workspace_id = ?",
+            (agent_id, wid),
+        )
+        agents_updated = c.rowcount
+
+        # 4. Scrub audit-log rows where the agent is the actor.
+        c = await self.db.execute(
+            "UPDATE audit_log SET agent_id = NULL, extra = '{}' "
+            "WHERE agent_id = ? AND workspace_id = ?",
+            (agent_id, wid),
+        )
+        audit_rows_scrubbed = c.rowcount
+
+        await self.db.commit()
+        return {
+            "facts_updated": facts_updated,
+            "conflicts_scrubbed": conflicts_scrubbed,
+            "agents_updated": agents_updated,
+            "conflicts_closed": 0,
+            "scope_permissions_deleted": 0,
+            "scopes_updated": 0,
+            "audit_rows_scrubbed": audit_rows_scrubbed,
+        }
+
+    async def gdpr_hard_erase_agent(self, agent_id: str) -> dict[str, int]:
+        """Hard-erase: wipe fact payload, retire current versions, cascade conflicts.
+
+        All statements execute before a single commit.  The FTS5 shadow table
+        is kept consistent by the facts_au trigger added in schema v10.
+        """
+        now = _now_iso()
+        wid = self.workspace_id
+
+        # 1. Replace fact payload with a per-row placeholder, close any still-
+        #    current validity windows, and null semantic fields.
+        #    content uses the fact id so each row is unique (avoids spurious
+        #    dedup matches if find_duplicate ever scans retired rows).
+        c = await self.db.execute(
+            """UPDATE facts
+               SET content      = '[gdpr:erased:' || id || ']',
+                   content_hash = 'gdpr:erased:' || id,
+                   engineer     = '[redacted]',
+                   provenance   = NULL,
+                   keywords     = NULL,
+                   entities     = NULL,
+                   embedding    = NULL,
+                   valid_until  = COALESCE(valid_until, ?)
+               WHERE agent_id = ? AND workspace_id = ?""",
+            (now, agent_id, wid),
+        )
+        facts_updated = c.rowcount
+
+        # 2a. Dismiss open conflicts that reference an erased fact.
+        c = await self.db.execute(
+            """UPDATE conflicts
+               SET status                    = 'dismissed',
+                   resolution_type           = 'gdpr_erasure',
+                   resolution                = '[gdpr:erased]',
+                   resolved_at               = ?,
+                   resolved_by               = 'gdpr',
+                   explanation               = '[redacted]',
+                   suggested_resolution      = NULL,
+                   suggested_resolution_type = NULL,
+                   suggested_winning_fact_id = NULL,
+                   suggestion_reasoning      = NULL
+               WHERE workspace_id = ?
+                 AND status = 'open'
+                 AND (fact_a_id IN (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?)
+                      OR fact_b_id IN (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?))""",
+            (now, wid, agent_id, wid, agent_id, wid),
+        )
+        conflicts_closed = c.rowcount
+
+        # 2b. Scrub free-text on already-resolved conflicts referencing erased facts.
+        c = await self.db.execute(
+            """UPDATE conflicts
+               SET explanation               = '[redacted]',
+                   resolution                = '[redacted]',
+                   suggested_resolution      = NULL,
+                   suggested_resolution_type = NULL,
+                   suggestion_reasoning      = NULL
+               WHERE workspace_id = ?
+                 AND status != 'open'
+                 AND (fact_a_id IN (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?)
+                      OR fact_b_id IN (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?))""",
+            (wid, agent_id, wid, agent_id, wid),
+        )
+        conflicts_scrubbed = c.rowcount
+
+        # 2c. Null suggested_winning_fact_id if it pointed at an erased fact.
+        await self.db.execute(
+            """UPDATE conflicts
+               SET suggested_winning_fact_id = NULL
+               WHERE workspace_id = ?
+                 AND suggested_winning_fact_id IN
+                     (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?)""",
+            (wid, agent_id, wid),
+        )
+
+        # 3. Redact the agents-registry row.
+        c = await self.db.execute(
+            "UPDATE agents SET engineer = '[redacted]', label = NULL "
+            "WHERE agent_id = ? AND workspace_id = ?",
+            (agent_id, wid),
+        )
+        agents_updated = c.rowcount
+
+        # 4. Remove scope-permission rows — no longer meaningful post-erasure.
+        c = await self.db.execute(
+            "DELETE FROM scope_permissions WHERE agent_id = ?",
+            (agent_id,),
+        )
+        scope_permissions_deleted = c.rowcount
+
+        # 5. Null owner_agent_id on scopes this agent owned.
+        c = await self.db.execute(
+            "UPDATE scopes SET owner_agent_id = NULL "
+            "WHERE owner_agent_id = ? AND workspace_id = ?",
+            (agent_id, wid),
+        )
+        scopes_updated = c.rowcount
+
+        # 6. Scrub audit-log rows: actor rows and rows tied to erased facts.
+        c = await self.db.execute(
+            "UPDATE audit_log SET agent_id = NULL, extra = '{}' "
+            "WHERE agent_id = ? AND workspace_id = ?",
+            (agent_id, wid),
+        )
+        audit_actor = c.rowcount
+        c = await self.db.execute(
+            """UPDATE audit_log
+               SET fact_id = NULL, extra = '{}'
+               WHERE workspace_id = ?
+                 AND fact_id IN
+                     (SELECT id FROM facts WHERE agent_id = ? AND workspace_id = ?)""",
+            (wid, agent_id, wid),
+        )
+        audit_fact = c.rowcount
+
+        await self.db.commit()
+        return {
+            "facts_updated": facts_updated,
+            "conflicts_closed": conflicts_closed,
+            "conflicts_scrubbed": conflicts_scrubbed,
+            "agents_updated": agents_updated,
+            "scope_permissions_deleted": scope_permissions_deleted,
+            "scopes_updated": scopes_updated,
+            "audit_rows_scrubbed": audit_actor + audit_fact,
+        }
 
 
 def _now_iso() -> str:

--- a/tests/test_gdpr_erasure.py
+++ b/tests/test_gdpr_erasure.py
@@ -1,0 +1,586 @@
+"""Tests for the GDPR subject-erasure pipeline.
+
+Covers:
+- Soft erase: engineer/provenance redacted, fact content preserved.
+- Hard erase: content wiped, valid_until closed, embedding nulled, keywords/entities cleared.
+- FTS sanity: erased content no longer returned by full-text search.
+- Conflict cascade: open conflicts dismissed, resolved conflicts text-scrubbed,
+  suggested_winning_fact_id nulled.
+- Agents table: engineer name redacted in registry.
+- scope_permissions deleted (hard erase only).
+- scopes.owner_agent_id nulled (hard erase).
+- Audit log: agent_id and fact_id cleared.
+- Control-agent isolation: facts from other agents are untouched.
+- Engine-level permission gate: PermissionError when not creator.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from engram.engine import EngramEngine
+from engram.storage import Storage
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fact(
+    *,
+    agent_id: str = "agent-alice",
+    engineer: str = "alice@example.com",
+    content: str = "Cache TTL is 300s",
+    scope: str = "infra",
+    keywords: str = '["cache","ttl"]',
+    entities: str = "[]",
+    provenance: str | None = "alice's notes",
+    embedding: bytes | None = b"\x00\x01\x02",
+    valid_until: str | None = None,
+) -> dict[str, Any]:
+    now = _ts()
+    return {
+        "id": uuid.uuid4().hex,
+        "lineage_id": uuid.uuid4().hex,
+        "content": content,
+        "content_hash": uuid.uuid4().hex,
+        "scope": scope,
+        "confidence": 0.9,
+        "fact_type": "observation",
+        "agent_id": agent_id,
+        "engineer": engineer,
+        "provenance": provenance,
+        "keywords": keywords,
+        "entities": entities,
+        "artifact_hash": None,
+        "embedding": embedding,
+        "embedding_model": "test",
+        "embedding_ver": "1.0",
+        "durability": "durable",
+        "ttl_days": None,
+        "committed_at": now,
+        "valid_from": now,
+        "valid_until": valid_until,
+    }
+
+
+def _conflict(
+    fact_a_id: str,
+    fact_b_id: str,
+    *,
+    status: str = "open",
+    explanation: str = "Contradiction detected",
+) -> dict[str, Any]:
+    """Minimal conflict dict matching the columns insert_conflict accepts."""
+    return {
+        "id": uuid.uuid4().hex,
+        "fact_a_id": fact_a_id,
+        "fact_b_id": fact_b_id,
+        "detected_at": _ts(),
+        "detection_tier": "tier1_nli",
+        "nli_score": 0.9,
+        "explanation": explanation,
+        "severity": "high",
+        "status": status,
+    }
+
+
+async def _insert_audit(storage: Storage, agent_id: str, fact_id: str | None = None) -> str:
+    entry_id = uuid.uuid4().hex
+    await storage.insert_audit_entry(
+        {
+            "id": entry_id,
+            "operation": "commit",
+            "agent_id": agent_id,
+            "fact_id": fact_id,
+            "conflict_id": None,
+            "extra": '{"scope":"infra"}',
+            "timestamp": _ts(),
+        }
+    )
+    return entry_id
+
+
+# ── storage-level soft erase ─────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def storage(tmp_path: Path):
+    db_path = tmp_path / "test.db"
+    s = Storage(db_path=db_path)
+    await s.connect()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_redacts_engineer(storage: Storage):
+    """Engineer and provenance are cleared; content is preserved."""
+    f = _fact(agent_id="agent-alice", engineer="alice@example.com", content="Cache TTL is 300s")
+    await storage.insert_fact(f)
+
+    stats = await storage.gdpr_soft_erase_agent("agent-alice")
+
+    row = await storage.get_fact_by_id(f["id"])
+    assert row is not None
+    assert row["engineer"] == "[redacted]"
+    assert row["provenance"] is None
+    # Content untouched in soft mode
+    assert row["content"] == "Cache TTL is 300s"
+    assert stats["facts_updated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_all_versions_same_agent(storage: Storage):
+    """Soft erase covers every version (all rows) for the agent."""
+    f1 = _fact(agent_id="agent-alice", content="Version 1")
+    f2 = _fact(agent_id="agent-alice", content="Version 2")
+    await storage.insert_fact(f1)
+    await storage.insert_fact(f2)
+
+    stats = await storage.gdpr_soft_erase_agent("agent-alice")
+
+    assert stats["facts_updated"] == 2
+    for fid in (f1["id"], f2["id"]):
+        row = await storage.get_fact_by_id(fid)
+        assert row["engineer"] == "[redacted]"
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_does_not_touch_other_agents(storage: Storage):
+    """Facts from other agents are completely untouched."""
+    alice = _fact(agent_id="agent-alice", engineer="alice@example.com")
+    bob = _fact(agent_id="agent-bob", engineer="bob@example.com", content="Bob's fact")
+    await storage.insert_fact(alice)
+    await storage.insert_fact(bob)
+
+    await storage.gdpr_soft_erase_agent("agent-alice")
+
+    bob_row = await storage.get_fact_by_id(bob["id"])
+    assert bob_row["engineer"] == "bob@example.com"
+    assert bob_row["content"] == "Bob's fact"
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_scrubs_conflict_text(storage: Storage):
+    """Conflict explanation and suggestion fields are scrubbed for conflicts
+    touching the erased agent's facts."""
+    alice_fact = _fact(agent_id="agent-alice")
+    bob_fact = _fact(agent_id="agent-bob")
+    await storage.insert_fact(alice_fact)
+    await storage.insert_fact(bob_fact)
+
+    c = _conflict(alice_fact["id"], bob_fact["id"], explanation="alice says X but bob says Y")
+    await storage.insert_conflict(c)
+    # Seed suggestion columns (separate call, matching production flow)
+    await storage.update_conflict_suggestion(
+        c["id"],
+        "Prefer alice's version",
+        "winner",
+        alice_fact["id"],
+        "alice is senior",
+        _ts(),
+    )
+
+    stats = await storage.gdpr_soft_erase_agent("agent-alice")
+    assert stats["conflicts_scrubbed"] >= 1
+
+    rows = await storage.get_conflicts(status="all")
+    hit = next(r for r in rows if r["id"] == c["id"])
+    assert hit["explanation"] == "[redacted]"
+    assert hit["suggested_resolution"] is None
+    assert hit["suggestion_reasoning"] is None
+    # Status is still open — soft erase does not close conflicts
+    assert hit["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_updates_agents_registry(storage: Storage):
+    """The agents table row has engineer redacted."""
+    await storage.upsert_agent("agent-alice", "alice@example.com")
+
+    await storage.gdpr_soft_erase_agent("agent-alice")
+
+    agent = await storage.get_agent("agent-alice")
+    assert agent is not None
+    assert agent["engineer"] == "[redacted]"
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_scrubs_audit_log(storage: Storage):
+    """Audit rows where agent_id matches are scrubbed."""
+    f = _fact(agent_id="agent-alice")
+    await storage.insert_fact(f)
+    audit_id = await _insert_audit(storage, "agent-alice", f["id"])
+
+    await storage.gdpr_soft_erase_agent("agent-alice")
+
+    # agent_id column is cleared — cannot fetch by agent_id any more
+    logs = await storage.get_audit_log(agent_id="agent-alice")
+    assert not any(r["id"] == audit_id for r in logs)
+
+
+# ── storage-level hard erase ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_wipes_content(storage: Storage):
+    """Fact content is replaced with a deterministic placeholder."""
+    f = _fact(agent_id="agent-alice", content="Secret design doc content")
+    await storage.insert_fact(f)
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    row = await storage.get_fact_by_id(f["id"])
+    assert row is not None
+    assert row["content"] == f"[gdpr:erased:{f['id']}]"
+    assert row["engineer"] == "[redacted]"
+    assert row["provenance"] is None
+    assert row["keywords"] is None
+    assert row["entities"] is None
+    assert row["embedding"] is None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_closes_validity_window(storage: Storage):
+    """Current facts (valid_until IS NULL) are retired."""
+    f = _fact(agent_id="agent-alice", valid_until=None)
+    await storage.insert_fact(f)
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    row = await storage.get_fact_by_id(f["id"])
+    assert row["valid_until"] is not None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_preserves_already_closed_valid_until(storage: Storage):
+    """If valid_until was already set, it is not overwritten."""
+    closed_ts = "2025-01-01T00:00:00+00:00"
+    f = _fact(agent_id="agent-alice", valid_until=closed_ts)
+    await storage.insert_fact(f)
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    row = await storage.get_fact_by_id(f["id"])
+    assert row["valid_until"] == closed_ts
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_content_hash_unique_per_row(storage: Storage):
+    """Each erased fact gets a distinct content_hash to prevent false dedup."""
+    f1 = _fact(agent_id="agent-alice", content="Fact 1")
+    f2 = _fact(agent_id="agent-alice", content="Fact 2")
+    await storage.insert_fact(f1)
+    await storage.insert_fact(f2)
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    r1 = await storage.get_fact_by_id(f1["id"])
+    r2 = await storage.get_fact_by_id(f2["id"])
+    assert r1["content_hash"] != r2["content_hash"]
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_dismisses_open_conflicts(storage: Storage):
+    """Open conflicts referencing an erased fact are dismissed with gdpr_erasure."""
+    alice_fact = _fact(agent_id="agent-alice")
+    bob_fact = _fact(agent_id="agent-bob")
+    await storage.insert_fact(alice_fact)
+    await storage.insert_fact(bob_fact)
+
+    c = _conflict(alice_fact["id"], bob_fact["id"], status="open")
+    await storage.insert_conflict(c)
+
+    stats = await storage.gdpr_hard_erase_agent("agent-alice")
+    assert stats["conflicts_closed"] == 1
+
+    rows = await storage.get_conflicts(status="all")
+    hit = next(r for r in rows if r["id"] == c["id"])
+    assert hit["status"] == "dismissed"
+    assert hit["resolution_type"] == "gdpr_erasure"
+    assert hit["explanation"] == "[redacted]"
+    assert hit["suggested_resolution"] is None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_scrubs_resolved_conflicts(storage: Storage):
+    """Already-resolved conflicts have their free-text fields scrubbed."""
+    alice_fact = _fact(agent_id="agent-alice")
+    bob_fact = _fact(agent_id="agent-bob")
+    await storage.insert_fact(alice_fact)
+    await storage.insert_fact(bob_fact)
+
+    c = _conflict(alice_fact["id"], bob_fact["id"], explanation="alice contradicts bob")
+    await storage.insert_conflict(c)
+    # Seed suggestion fields
+    await storage.update_conflict_suggestion(
+        c["id"],
+        "Use alice's version",
+        "winner",
+        alice_fact["id"],
+        "alice is correct",
+        _ts(),
+    )
+    # Resolve it so status='resolved' with a resolution string
+    await storage.resolve_conflict(c["id"], "winner", "human resolution text", "human")
+
+    stats = await storage.gdpr_hard_erase_agent("agent-alice")
+    assert stats["conflicts_scrubbed"] >= 1
+
+    rows = await storage.get_conflicts(status="all")
+    hit = next(r for r in rows if r["id"] == c["id"])
+    assert hit["status"] == "resolved"  # status unchanged by hard erase (only open → dismissed)
+    assert hit["explanation"] == "[redacted]"
+    assert hit["resolution"] == "[redacted]"
+    assert hit["suggested_resolution"] is None
+    assert hit["suggestion_reasoning"] is None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_nulls_suggested_winning_fact_id(storage: Storage):
+    """suggested_winning_fact_id is nulled when it points at an erased fact."""
+    alice_fact = _fact(agent_id="agent-alice")
+    bob_fact = _fact(agent_id="agent-bob")
+    await storage.insert_fact(alice_fact)
+    await storage.insert_fact(bob_fact)
+
+    c = _conflict(alice_fact["id"], bob_fact["id"])
+    await storage.insert_conflict(c)
+    # Point suggested_winning_fact_id at alice's fact
+    await storage.update_conflict_suggestion(
+        c["id"],
+        "Pick alice",
+        "winner",
+        alice_fact["id"],  # <-- this should be nulled
+        "alice is newer",
+        _ts(),
+    )
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    rows = await storage.get_conflicts(status="all")
+    hit = next(r for r in rows if r["id"] == c["id"])
+    assert hit["suggested_winning_fact_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_deletes_scope_permissions(storage: Storage):
+    """scope_permissions rows for the agent are removed."""
+    await storage.set_scope_permission("agent-alice", "infra")
+
+    stats = await storage.gdpr_hard_erase_agent("agent-alice")
+    assert stats["scope_permissions_deleted"] == 1
+
+    perm = await storage.get_scope_permission("agent-alice", "infra")
+    assert perm is None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_scrubs_audit_log(storage: Storage):
+    """Audit rows by actor and by fact_id are scrubbed."""
+    f = _fact(agent_id="agent-alice")
+    await storage.insert_fact(f)
+    actor_audit_id = await _insert_audit(storage, "agent-alice", None)
+    fact_audit_id = await _insert_audit(storage, "agent-other", f["id"])
+
+    stats = await storage.gdpr_hard_erase_agent("agent-alice")
+    assert stats["audit_rows_scrubbed"] >= 2
+
+    # Actor row: agent_id cleared
+    actor_logs = await storage.get_audit_log(agent_id="agent-alice")
+    assert not any(r["id"] == actor_audit_id for r in actor_logs)
+
+    # Fact-tied row: fact_id cleared (we can still fetch by id via get_audit_log
+    # — fact_id is cleared, so we cannot filter by it; check absence another way)
+    all_logs = await storage.get_audit_log(limit=1000)
+    fact_log = next((r for r in all_logs if r["id"] == fact_audit_id), None)
+    assert fact_log is not None
+    assert fact_log["fact_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_does_not_touch_other_agents(storage: Storage):
+    """Facts, conflicts, and audit rows belonging to other agents are untouched."""
+    alice = _fact(agent_id="agent-alice", content="Alice's fact")
+    bob = _fact(agent_id="agent-bob", engineer="bob@example.com", content="Bob's fact")
+    await storage.insert_fact(alice)
+    await storage.insert_fact(bob)
+
+    # Conflict between two bob facts — should not be touched
+    bob2 = _fact(agent_id="agent-bob", content="Bob's second fact")
+    await storage.insert_fact(bob2)
+    c_bob = _conflict(bob["id"], bob2["id"], explanation="bob conflict")
+    await storage.insert_conflict(c_bob)
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    bob_row = await storage.get_fact_by_id(bob["id"])
+    assert bob_row["engineer"] == "bob@example.com"
+    assert bob_row["content"] == "Bob's fact"
+
+    rows = await storage.get_conflicts(status="all")
+    bob_conflict = next(r for r in rows if r["id"] == c_bob["id"])
+    assert bob_conflict["status"] == "open"
+    assert bob_conflict["explanation"] == "bob conflict"
+
+
+# ── FTS sanity (hard erase) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_removes_content_from_fts(storage: Storage):
+    """After hard erase the unique token in the erased fact cannot be found via FTS."""
+    unique_token = "xQzR7YpL2mNv9wK"
+    f = _fact(agent_id="agent-alice", content=f"Super secret token is {unique_token}")
+    await storage.insert_fact(f)
+
+    # Confirm it is reachable before erase
+    rowids_before = await storage.fts_search(unique_token, limit=10)
+    assert rowids_before, "Token should appear in FTS before erase"
+
+    await storage.gdpr_hard_erase_agent("agent-alice")
+
+    rowids_after = await storage.fts_search(unique_token, limit=10)
+    # The placeholder content does not contain the token, so FTS must return nothing
+    assert not rowids_after, "Token must not appear in FTS after hard erase"
+
+
+# ── engine-level permission gate ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_engine_gdpr_erase_requires_creator(storage: Storage):
+    """PermissionError raised when workspace is not a creator workspace."""
+    engine = EngramEngine(storage)
+
+    mock_ws = MagicMock()
+    mock_ws.is_creator = False
+
+    with patch("engram.workspace.read_workspace", return_value=mock_ws):
+        with pytest.raises(PermissionError, match="workspace creator"):
+            await engine.gdpr_erase_agent("agent-alice", "soft")
+
+
+@pytest.mark.asyncio
+async def test_engine_gdpr_erase_no_workspace_raises(storage: Storage):
+    """PermissionError raised when no workspace.json is present."""
+    engine = EngramEngine(storage)
+
+    with patch("engram.workspace.read_workspace", return_value=None):
+        with pytest.raises(PermissionError):
+            await engine.gdpr_erase_agent("agent-alice", "soft")
+
+
+@pytest.mark.asyncio
+async def test_engine_gdpr_erase_soft_succeeds_as_creator(storage: Storage):
+    """Engine soft erase succeeds when is_creator=True."""
+    engine = EngramEngine(storage)
+    f = _fact(agent_id="agent-alice")
+    await storage.insert_fact(f)
+
+    mock_ws = MagicMock()
+    mock_ws.is_creator = True
+
+    with patch("engram.workspace.read_workspace", return_value=mock_ws):
+        result = await engine.gdpr_erase_agent("agent-alice", "soft", actor="test")
+
+    assert result["erased_agent_id"] == "agent-alice"
+    assert result["mode"] == "soft"
+    assert result["stats"]["facts_updated"] == 1
+    row = await storage.get_fact_by_id(f["id"])
+    assert row["engineer"] == "[redacted]"
+
+
+@pytest.mark.asyncio
+async def test_engine_gdpr_erase_hard_succeeds_as_creator(storage: Storage):
+    """Engine hard erase closes facts and returns expected stats."""
+    engine = EngramEngine(storage)
+    f = _fact(agent_id="agent-alice")
+    await storage.insert_fact(f)
+    await storage.upsert_agent("agent-alice", "alice@example.com")
+
+    mock_ws = MagicMock()
+    mock_ws.is_creator = True
+
+    with patch("engram.workspace.read_workspace", return_value=mock_ws):
+        result = await engine.gdpr_erase_agent("agent-alice", "hard", actor="test")
+
+    assert result["mode"] == "hard"
+    row = await storage.get_fact_by_id(f["id"])
+    assert row["valid_until"] is not None
+    assert row["content"].startswith("[gdpr:erased:")
+
+
+@pytest.mark.asyncio
+async def test_engine_gdpr_erase_invalid_mode_raises(storage: Storage):
+    """ValueError is raised before the workspace check, so no patch needed."""
+    engine = EngramEngine(storage)
+
+    with pytest.raises(ValueError, match="mode must be"):
+        await engine.gdpr_erase_agent("agent-alice", "delete")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_engine_gdpr_erase_empty_agent_id_raises(storage: Storage):
+    """ValueError is raised before the workspace check, so no patch needed."""
+    engine = EngramEngine(storage)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        await engine.gdpr_erase_agent("", "soft")
+
+
+# ── return value shape ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_soft_erase_stats_keys(storage: Storage):
+    """Return dict contains all expected keys."""
+    stats = await storage.gdpr_soft_erase_agent("nonexistent-agent")
+    expected = {
+        "facts_updated",
+        "conflicts_scrubbed",
+        "agents_updated",
+        "conflicts_closed",
+        "scope_permissions_deleted",
+        "scopes_updated",
+        "audit_rows_scrubbed",
+    }
+    assert set(stats.keys()) == expected
+
+
+@pytest.mark.asyncio
+async def test_hard_erase_stats_keys(storage: Storage):
+    """Return dict contains all expected keys."""
+    stats = await storage.gdpr_hard_erase_agent("nonexistent-agent")
+    expected = {
+        "facts_updated",
+        "conflicts_closed",
+        "conflicts_scrubbed",
+        "agents_updated",
+        "scope_permissions_deleted",
+        "scopes_updated",
+        "audit_rows_scrubbed",
+    }
+    assert set(stats.keys()) == expected
+
+
+@pytest.mark.asyncio
+async def test_erase_nonexistent_agent_is_zero_noop(storage: Storage):
+    """Erasing an agent_id that has no data returns zeros and does not error."""
+    stats_soft = await storage.gdpr_soft_erase_agent("agent-nobody")
+    assert stats_soft["facts_updated"] == 0
+
+    stats_hard = await storage.gdpr_hard_erase_agent("agent-nobody")
+    assert stats_hard["facts_updated"] == 0
+    assert stats_hard["conflicts_closed"] == 0


### PR DESCRIPTION
Resolves #49 

- Added `EngramEngine.gdpr_erase_agent()` with input validation, `is_creator` permission gate, and a non-PII audit entry
- Added `gdpr_soft_erase_agent` and `gdpr_hard_erase_agent` abstract methods to `BaseStorage`
- Implemented both methods in `SQLiteStorage` as set-based SQL in a single atomic commit (8 statements, no Python loops)
- Mirrored both storage methods in `PostgresStorage` using `async with conn.transaction()` for atomicity
- Soft erase redacted `engineer`, `provenance`, conflict free-text, agents-registry row, and audit-log actor references
- Hard erase additionally wiped fact content with a per-row placeholder, cleared embeddings/keywords/entities, closed validity windows, dismissed open conflicts, scrubbed resolved conflict text, deleted scope permissions, and cleared audit fact-id references
- Added `engram_gdpr_erase` MCP tool with `destructiveHint: True` and detailed tool description
- Added `engram gdpr erase --agent-id --mode --yes` CLI subcommand with interactive confirmation and count summary
- Added `POST /api/gdpr/erase` REST endpoint with structured 403/400/500 error responses
- Bumped schema to v10 and added SQLite `facts_au` AFTER UPDATE trigger to keep FTS5 in sync when fact content is overwritten
- Added 26 async tests in `test_gdpr_erasure.py` covering soft/hard erase, FTS sanity, conflict cascade, audit scrub, permission gate, and control-agent isolation
- Updated `PRIVACY_ARCHITECTURE.md` with a new GDPR erasure section covering both modes, field-by-field comparison, and operator checklist
- Updated `ARCHITECTURE.md` with revised module blurbs and a new GDPR erasure path subsection
- Updated `MIGRATION_SCHEMA.md` with schema version history table and v10 FTS trigger explanation
- Updated `CLAUDE.md` with correct schema version, tool count, new CLI command, and new MCP tool