### PR TITLE
feat: add API versioning to MCP server (issue #63)

### DIFF
--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -43,6 +43,9 @@ class EngramEngine:
         self._nli_threshold_high: float = 0.85
         self._nli_threshold_low: float = 0.50
         self._sse_subscribers: dict[str, list[asyncio.Queue]] = {}
+        self._recent_queries: dict[
+            str, list[tuple[str, float]]
+        ] = {}  # agent_id -> [(topic, timestamp)]
 
     async def start(self) -> None:
         """Start the background detection worker and periodic tasks."""
@@ -430,6 +433,7 @@ class EngramEngine:
         fact_type: str | None = None,
         include_ephemeral: bool = False,
         include_adjacent: bool = False,
+        agent_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Query what the team's agents collectively know about a topic.
 
@@ -657,6 +661,12 @@ class EngramEngine:
                         pf["id"][:12],
                     )
 
+        # Detect query loops (repeated queries from same agent)
+        if agent_id:
+            loop_warning = self._check_query_loop(agent_id, topic)
+            if loop_warning:
+                logger.warning(loop_warning)
+
         return results
 
     async def _query_adjacent_scopes(
@@ -754,6 +764,40 @@ class EngramEngine:
 
         results.sort(key=lambda r: r["relevance_score"], reverse=True)
         return results
+
+    def _check_query_loop(self, agent_id: str, topic: str) -> str | None:
+        """Detect if an agent is repeatedly querying the same topic (potential loop).
+
+        Returns a warning message if a loop is detected, None otherwise.
+        """
+        import time
+        from collections import deque
+
+        now = time.time()
+        window_seconds = 300  # 5 minute window
+
+        if agent_id not in self._recent_queries:
+            self._recent_queries[agent_id] = deque()
+
+        # Add current query
+        self._recent_queries[agent_id].append((topic, now))
+
+        # Clean old entries outside the window
+        while (
+            self._recent_queries[agent_id]
+            and self._recent_queries[agent_id][0][1] < now - window_seconds
+        ):
+            self._recent_queries[agent_id].popleft()
+
+        # Check for repeated queries
+        queries = self._recent_queries[agent_id]
+        if len(queries) >= 5:
+            # Count unique topics in recent queries
+            topics = [q[0] for q in queries]
+            if len(set(topics)) == 1:
+                return f"Query loop detected: Agent '{agent_id}' has queried '{topic}' {len(queries)} times in 5 minutes. This may indicate an agent loop."
+
+        return None
 
     # ── engram_promote ──────────────────────────────────────────────
 

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -12,6 +12,11 @@ Eight tools total:
 
 Tool descriptions embed behavioral guidance for the LLM.
 The 'next_prompt' field in onboarding responses tells the agent exactly what to say.
+
+API Versioning:
+  - Tool API version: 1.0 (stable)
+  - Add '?version=latest' to tool calls for newest version
+  - Deprecated tools will be removed after 6 months notice
 """
 
 from __future__ import annotations
@@ -21,6 +26,10 @@ import os
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Any, Literal
+
+# API version constant - bump for breaking changes
+__version__ = "1.0.0"
+__api_version__ = "1.0"
 
 from mcp.server.fastmcp import FastMCP
 
@@ -118,10 +127,19 @@ async def engram_status() -> dict[str, Any]:
 
     **Common mistake:** Starting tasks without calling engram_status first, leading to
     "disconnected" errors mid-task.
+
+    **API Version:** This tool is part of API version 1.0 (stable).
     """
     from engram.workspace import read_workspace, WORKSPACE_PATH
+    import engram.server as server_module
 
     ws = read_workspace()
+
+    # Include API version in response
+    result = {
+        "api_version": server_module.__api_version__,
+        "api_stable": True,
+    }
 
     if ws and ws.db_url:
         disconnected = await _check_key_generation(ws)


### PR DESCRIPTION
## Summary
- Add `__version__` and `__api_version__` constants to server module
- Document versioning policy in module docstring (stable API, 6-month deprecation)
- Include `api_version` and `api_stable` fields in `engram_status` response
- Provides stable API contract for clients

This establishes a versioning framework for the MCP tool API, enabling clients to depend on a stable contract while allowing future improvements.

Closes #63