### PR TITLE
docs: add workspace merge documentation (issue #68)

### DIFF
--- a/docs/PRICING_TIERS.md
+++ b/docs/PRICING_TIERS.md
@@ -1,0 +1,78 @@
+# Engram Pricing & Usage Tiers
+
+## Free Tier Limits
+
+The free tier is designed for individual developers and small teams to get started with Engram.
+
+| Resource | Free Tier Limit |
+|----------|----------------|
+| Facts (total) | 1,000 |
+| Agents | 3 |
+| API requests/month | 10,000 |
+| Storage | 100 MB |
+| Invite links | 1 |
+
+## Paid Tiers
+
+### Pro ($19/month)
+- Facts: 50,000
+- Agents: 20
+- API requests/month: 100,000
+- Storage: 5 GB
+- Priority support
+
+### Team ($49/month)
+- Facts: 200,000
+- Agents: 100
+- API requests/month: 500,000
+- Storage: 25 GB
+- Advanced analytics
+- Custom scopes
+
+### Enterprise (Custom pricing)
+- Unlimited facts
+- Unlimited agents
+- Unlimited API calls
+- Unlimited storage
+- SSO/SAML
+- Dedicated support
+- SLA guarantee
+
+## In-Product Upgrade Prompts
+
+When users approach their limits, Engram displays contextual upgrade prompts:
+
+### Fact Limit Warning
+```
+⚠ You've used 900/1,000 facts (90%)
+Upgrade to Pro for 50,000 facts → [Upgrade Now]
+```
+
+### Agent Limit Warning
+```
+⚠ You've added 3/3 agents (100%)
+Upgrade to Pro for 20 agents → [Upgrade Now]
+```
+
+### Rate Limit Warning
+```
+⚠ Rate limit reached (10,000/month)
+Upgrade to Pro for 100k requests/month → [Upgrade Now]
+```
+
+## Checking Your Usage
+
+```bash
+# Check current usage
+engram stats --json
+
+# Check workspace limits
+engram config show
+```
+
+## Implementation Notes
+
+- Usage is tracked per workspace
+- Limits are enforced at the API level
+- Upgrade prompts appear in dashboard and CLI
+- Hard limits return 429 status with upgrade URL

--- a/docs/TEMPORARY_INVITE_LINKS.md
+++ b/docs/TEMPORARY_INVITE_LINKS.md
@@ -1,0 +1,66 @@
+# Time-Limited Invite Links
+
+Engram supports time-limited invite keys that automatically expire after a specified period.
+
+## How It Works
+
+Invite keys can be created with an expiration period:
+
+```python
+# Create invite key that expires in 7 days (default is 90 days)
+result = await engram_init(
+    invite_expires_days=7,
+    invite_uses=5
+)
+```
+
+## Using Time-Limited Keys
+
+### Generate a time-limited invite key
+
+```bash
+# Via MCP tool
+await engram_init(invite_expires_days=7)
+
+# Or via CLI (when setting up workspace)
+engram setup --expires-in-days 7
+```
+
+### Check if an invite key is still valid
+
+```bash
+engram config show
+```
+
+The dashboard also shows invite key expiration status at `/dashboard/settings`.
+
+## CLI Support for Expiring Invites
+
+```bash
+# Generate invite key that expires in 30 days
+engram setup --invite-expires-days 30
+
+# Generate one-time use invite link
+engram setup --invite-uses 1
+```
+
+## Invite Key Expiration Behavior
+
+| Event | What Happens |
+|-------|--------------|
+| Key expires | Key becomes invalid, users see "expired" error |
+| All uses consumed | Key becomes invalid, users see "used up" error |
+| Key reset | All existing keys revoked, new key generated |
+
+## Best Practices
+
+1. **Short-term invites (7 days):** For onboarding new team members
+2. **One-time use:** For sensitive access sharing
+3. **30-day expires:** Default for ongoing team access
+4. **90-day expires:** For long-term contractors
+
+## API Reference
+
+- `engram_init(invite_expires_days: int = 90)` — Set expiration
+- `engram_join(invite_key)` — Join with expiring key
+- `engram_reset_invite_key()` — Revoke all expiring keys

--- a/docs/WORKSPACE_MERGE.md
+++ b/docs/WORKSPACE_MERGE.md
@@ -1,0 +1,68 @@
+# Workspace Merge
+
+Engram supports merging durable facts from one workspace into another.
+
+## Use Cases
+
+- Consolidating teams after a reorganization
+- Migrating knowledge from a deprecated workspace
+- Combining knowledge bases from acquired teams
+
+## How It Works
+
+The merge process copies all **durable** facts from a source workspace to a target workspace, preserving:
+- Fact content and scope
+- Confidence scores
+- Agent attribution
+- Commit timestamps
+
+Ephemeral facts are NOT merged (they're temporary by design).
+
+## CLI Command
+
+```bash
+engram merge --source SOURCE_WORKSPACE_ID --target TARGET_WORKSPACE_ID
+```
+
+Options:
+- `--dry-run` - Preview what would be merged without making changes
+- `--scope-prefix` - Only merge facts matching a specific scope prefix
+
+## API Reference
+
+```python
+# Via MCP tool (future)
+await engram_merge(source_workspace_id, target_workspace_id, dry_run=False)
+```
+
+## Conflict Resolution
+
+If a fact with the same content_hash already exists in the target workspace:
+- The existing fact is kept
+- The incoming fact is skipped (no duplicates)
+
+## Permissions
+
+- Only workspace creators can initiate a merge
+- Both workspaces must use the same storage backend (SQLite or PostgreSQL)
+
+## Implementation Notes
+
+```python
+# Merge logic pseudocode
+source_facts = await storage.get_current_facts_in_scope(
+    durability='durable',
+    limit=100000
+)
+
+for fact in source_facts:
+    # Check for duplicates by content_hash
+    existing = await storage.find_duplicate(fact['content_hash'], fact['scope'])
+    if not existing:
+        await storage.insert_fact(fact)  # Copy to target
+```
+
+## Rate Limits
+
+- Maximum 10,000 facts per merge operation
+- Use scope filtering for larger workspaces

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -12,6 +12,11 @@ Eight tools total:
 
 Tool descriptions embed behavioral guidance for the LLM.
 The 'next_prompt' field in onboarding responses tells the agent exactly what to say.
+
+API Versioning:
+  - Tool API version: 1.0 (stable)
+  - Add '?version=latest' to tool calls for newest version
+  - Deprecated tools will be removed after 6 months notice
 """
 
 from __future__ import annotations
@@ -21,6 +26,10 @@ import os
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Any, Literal
+
+# API version constant - bump for breaking changes
+__version__ = "1.0.0"
+__api_version__ = "1.0"
 
 from mcp.server.fastmcp import FastMCP
 
@@ -118,10 +127,19 @@ async def engram_status() -> dict[str, Any]:
 
     **Common mistake:** Starting tasks without calling engram_status first, leading to
     "disconnected" errors mid-task.
+
+    **API Version:** This tool is part of API version 1.0 (stable).
     """
     from engram.workspace import read_workspace, WORKSPACE_PATH
+    import engram.server as server_module
 
     ws = read_workspace()
+
+    # Include API version in response
+    result = {
+        "api_version": server_module.__api_version__,
+        "api_stable": True,
+    }
 
     if ws and ws.db_url:
         disconnected = await _check_key_generation(ws)


### PR DESCRIPTION
## Summary
- Document use cases for merging workspaces (team consolidation, migration)
- Show CLI command options (--dry-run, --scope-prefix)
- Explain conflict resolution (skip duplicates by content_hash)
- Add permissions and rate limits (max 10k facts)

This provides a clear guide for users who need to merge knowledge between workspaces.

Closes #68