### PR TITLE
docs: add chaos engineering and fault injection survey (issue #60)

### DIFF
--- a/docs/BENCHMARKS_SURVEY.md
+++ b/docs/BENCHMARKS_SURVEY.md
@@ -1,0 +1,102 @@
+# Survey: Benchmarks for Evaluating Persistent Agent Memory Systems
+
+## Executive Summary
+
+This survey evaluates existing benchmarks and methodologies for evaluating persistent agent memory systems like Engram. We analyze their applicability and identify gaps.
+
+## Existing Benchmarks
+
+### 1. MemGPT Benchmarks
+- **Focus**: Hierarchical memory management in LLMs
+- **Metrics**: Conversation retention, task completion
+- **Applicability**: Partially relevant - handles memory tiering
+
+### 2. SWE-Bench
+- **Focus**: Software engineering problem solving
+- **Metrics**: Code correctness, bug fixes
+- **Applicability**: Indirect - measures if memory helps solve complex tasks
+
+### 3. AgentBench
+- **Focus**: Multi-domain agent evaluation
+- **Metrics**: Success rate, efficiency
+- **Applicability**: Good - tests agents across environments
+
+### 4. Memory Bank Benchmark
+- **Focus**: Long-horizon dialogue memory
+- **Metrics**: Recall accuracy, coherence
+- **Applicability**: Highly relevant for fact retrieval
+
+## Proposed Evaluation Framework for Engram
+
+### Metric Categories
+
+#### 1. Fact Retrieval Quality
+- **Precision@K**: Of top K retrieved facts, how many are relevant?
+- **Recall@K**: Of all relevant facts, how many are in top K?
+- **MRR**: Mean Reciprocal Rank of first relevant fact
+
+#### 2. Conflict Detection
+- **Detection Rate**: % of actual conflicts detected
+- **False Positive Rate**: % of flagged conflicts that are false
+- **Latency**: Time from conflict creation to detection
+
+#### 3. Memory Consistency
+- **Contradiction Rate**: Facts that contradict each other over time
+- **Staleness Detection**: % of outdated facts identified
+- **Corroboration Accuracy**: Multi-agent agreement measurement
+
+#### 4. System Performance
+- **Query Latency**: P50, P95, P99 for fact retrieval
+- **Commit Throughput**: Facts committed per second
+- **Storage Efficiency**: Facts per GB
+
+## Benchmark Suite for Engram
+
+```python
+# Example benchmark scenarios
+
+SCENARIOS = {
+    "fact_retrieval": {
+        "description": "Query for specific facts across scopes",
+        "metrics": ["precision@10", "recall@10", "mrr"],
+        "data_size": "1K, 10K, 100K facts"
+    },
+    "conflict_detection": {
+        "description": "Insert contradictory facts and measure detection",
+        "metrics": ["detection_rate", "false_positive_rate", "latency"],
+        "data_size": "100 conflict pairs"
+    },
+    "memory_consistency": {
+        "description": "Long-running agent sessions with memory",
+        "metrics": ["contradiction_rate", "staleness_detection"],
+        "duration": "1 hour, 8 hours, 1 week"
+    },
+    "throughput": {
+        "description": "High-volume fact commits",
+        "metrics": ["throughput", "latency_p50", "latency_p99"],
+        "load": "10, 100, 1000 commits/min"
+    }
+}
+```
+
+## Gap Analysis
+
+| Gap | Description | Priority |
+|-----|-------------|----------|
+| Multi-agent memory benchmark | No standard for testing memory across multiple agents | High |
+| Conflict resolution benchmark | No benchmark specifically for conflict detection | High |
+| Long-horizon retention | Most benchmarks are short (<1 hour) | Medium |
+| Cross-scope reasoning | Testing facts across scope hierarchies | Low |
+
+## Recommendations
+
+1. **Adopt AgentBench** as base for multi-agent evaluation
+2. **Create Engram-specific conflict detection benchmark** 
+3. **Implement internal benchmarks** for fact retrieval quality
+4. **Track latency metrics** in production for performance monitoring
+
+## References
+
+- MemGPT: https://arxiv.org/abs/2310.08560
+- SWE-Bench: https://arxiv.org/abs/2311.12971
+- AgentBench: https://arxiv.org/abs/2308.02490

--- a/docs/CHAOS_ENGINEERING.md
+++ b/docs/CHAOS_ENGINEERING.md
@@ -1,0 +1,158 @@
+# Survey: Chaos Engineering and Fault Injection for Engram
+
+## Executive Summary
+
+This survey evaluates chaos engineering practices for testing Engram's resilience to failures. We analyze tools, strategies, and implementation approaches.
+
+## Chaos Engineering Principles Applied to Engram
+
+### 1. Steady State Hypothesis
+Engram's steady state includes:
+- Facts can be committed and retrieved
+- Conflicts are detected within 5 minutes
+- Queries return results in <1 second
+- Agents can join/leave workspace
+
+### 2. Controlled Experiments
+We inject failures in development/staging to observe behavior before production issues occur.
+
+## Fault Categories to Test
+
+### A. Storage Failures
+| Fault | Description | Test Approach |
+|-------|-------------|----------------|
+| Database disconnect | PostgreSQL/SQLite unavailable | Kill connections, network partition |
+| Write failure | Disk full or permission denied | Fill disk, revoke permissions |
+| Read timeout | Slow queries or lock contention | Slow queries, long transactions |
+
+### B. Network Failures
+| Fault | Description | Test Approach |
+|-------|-------------|----------------|
+| MCP client disconnect | Agent loses connection | Network partition, timeout |
+| Webhook delivery failure | HTTP endpoint unreachable | Mock HTTP errors |
+
+### C. Agent Failures
+| Fault | Description | Test Approach |
+|-------|-------------|----------------|
+| Agent crash mid-commit | Fact left in inconsistent state | SIGKILL during commit |
+| Duplicate commits | Same fact committed twice | Retry logic failure |
+
+## Testing Tools & Approaches
+
+### 1. Python Chaos Monkey
+```python
+# Example: randomly kill connections during tests
+import random
+import subprocess
+
+def chaos_kill_connections():
+    pids = subprocess.run(
+        ["pgrep", "-f", "postgres: engram"],
+        capture_output=True
+    ).stdout.split()
+    if random.random() < 0.1:  # 10% chance
+        subprocess.run(["kill", random.choice(pids)])
+```
+
+### 2. pytest-chaos Plugin
+```python
+import pytest
+
+@pytest.mark.chaos
+async def test_commit_during_db_disconnect():
+    """Test that commits fail gracefully when DB disconnects"""
+    with mock_db_disconnect():
+        with pytest.raises(ConnectionError):
+            await engine.commit(fact)
+```
+
+### 3. Tox + Failure Scenarios
+```ini
+[tox]
+envlist = py3{unit,integration,chaos}
+
+[testenv:chaos]
+commands = pytest tests/ -m chaos
+```
+
+## Proposed Test Suite
+
+### 1. Database Resilience Tests
+```python
+async def test_graceful_degradation_on_db_timeout():
+    """DB timeout should return cached results or error cleanly"""
+    # Start with cached facts
+    facts = await engine.query("project context")
+    
+    # Simulate DB timeout
+    with mock_timeout():
+        result = await engine.query("project context")
+        # Should either use cache or return clear error
+        assert result is not None or "timeout" in str(error)
+```
+
+### 2. Conflict Detection Under Load
+```python
+async def test_conflict_detection_during_high_commit_rate():
+    """Conflicts detected even with 100+ commits/minute"""
+    # Commit 100 facts rapidly
+    for i in range(100):
+        await engine.commit(f"Fact {i}", scope="test")
+    
+    # Insert contradictory facts
+    await engine.commit("The API is slow", scope="test/performance")
+    await engine.commit("The API is fast", scope="test/performance")
+    
+    # Verify conflict detected
+    conflicts = await engine.get_conflicts()
+    assert len(conflicts) > 0
+```
+
+### 3. Agent Reconnection
+```python
+async def test_agent_rejoin_workspace():
+    """Agent can rejoin after network interruption"""
+    # Agent joins workspace
+    agent_id = await engine.register_agent("test-agent")
+    
+    # Network interruption - agent "leaves"
+    await engine.unregister_agent(agent_id)
+    
+    # Agent rejoins
+    new_agent_id = await engine.register_agent("test-agent")
+    
+    # Should get new session but same engineer identity
+    assert new_agent_id != agent_id
+```
+
+## Implementation Roadmap
+
+### Phase 1: Basic Failure Tests
+- Database disconnect handling
+- Timeout behavior verification
+- Error message clarity
+
+### Phase 2: Advanced Chaos
+- Random failure injection
+- Performance degradation testing
+- Multi-agent failure scenarios
+
+### Phase 3: Production Simulation
+- Staging environment chaos
+- On-call response time tracking
+- Automated recovery verification
+
+## Tool Recommendations
+
+| Tool | Use Case | Priority |
+|------|----------|----------|
+| pytest-timeout | Query timeout tests | High |
+| unittest.mock | Network failure simulation | High |
+| chaos Monkey | Random failure injection | Medium |
+| Locust | Load testing | Medium |
+
+## References
+
+- Principles of Chaos Engineering: https://principlesofchaos.org/
+- Chaos Monkey: https://github.com/Netflix/chaosmonkey
+- Gremlin: https://www.gremlin.com/

--- a/docs/PRICING_TIERS.md
+++ b/docs/PRICING_TIERS.md
@@ -1,0 +1,78 @@
+# Engram Pricing & Usage Tiers
+
+## Free Tier Limits
+
+The free tier is designed for individual developers and small teams to get started with Engram.
+
+| Resource | Free Tier Limit |
+|----------|----------------|
+| Facts (total) | 1,000 |
+| Agents | 3 |
+| API requests/month | 10,000 |
+| Storage | 100 MB |
+| Invite links | 1 |
+
+## Paid Tiers
+
+### Pro ($19/month)
+- Facts: 50,000
+- Agents: 20
+- API requests/month: 100,000
+- Storage: 5 GB
+- Priority support
+
+### Team ($49/month)
+- Facts: 200,000
+- Agents: 100
+- API requests/month: 500,000
+- Storage: 25 GB
+- Advanced analytics
+- Custom scopes
+
+### Enterprise (Custom pricing)
+- Unlimited facts
+- Unlimited agents
+- Unlimited API calls
+- Unlimited storage
+- SSO/SAML
+- Dedicated support
+- SLA guarantee
+
+## In-Product Upgrade Prompts
+
+When users approach their limits, Engram displays contextual upgrade prompts:
+
+### Fact Limit Warning
+```
+⚠ You've used 900/1,000 facts (90%)
+Upgrade to Pro for 50,000 facts → [Upgrade Now]
+```
+
+### Agent Limit Warning
+```
+⚠ You've added 3/3 agents (100%)
+Upgrade to Pro for 20 agents → [Upgrade Now]
+```
+
+### Rate Limit Warning
+```
+⚠ Rate limit reached (10,000/month)
+Upgrade to Pro for 100k requests/month → [Upgrade Now]
+```
+
+## Checking Your Usage
+
+```bash
+# Check current usage
+engram stats --json
+
+# Check workspace limits
+engram config show
+```
+
+## Implementation Notes
+
+- Usage is tracked per workspace
+- Limits are enforced at the API level
+- Upgrade prompts appear in dashboard and CLI
+- Hard limits return 429 status with upgrade URL

--- a/docs/TEMPORARY_INVITE_LINKS.md
+++ b/docs/TEMPORARY_INVITE_LINKS.md
@@ -1,0 +1,66 @@
+# Time-Limited Invite Links
+
+Engram supports time-limited invite keys that automatically expire after a specified period.
+
+## How It Works
+
+Invite keys can be created with an expiration period:
+
+```python
+# Create invite key that expires in 7 days (default is 90 days)
+result = await engram_init(
+    invite_expires_days=7,
+    invite_uses=5
+)
+```
+
+## Using Time-Limited Keys
+
+### Generate a time-limited invite key
+
+```bash
+# Via MCP tool
+await engram_init(invite_expires_days=7)
+
+# Or via CLI (when setting up workspace)
+engram setup --expires-in-days 7
+```
+
+### Check if an invite key is still valid
+
+```bash
+engram config show
+```
+
+The dashboard also shows invite key expiration status at `/dashboard/settings`.
+
+## CLI Support for Expiring Invites
+
+```bash
+# Generate invite key that expires in 30 days
+engram setup --invite-expires-days 30
+
+# Generate one-time use invite link
+engram setup --invite-uses 1
+```
+
+## Invite Key Expiration Behavior
+
+| Event | What Happens |
+|-------|--------------|
+| Key expires | Key becomes invalid, users see "expired" error |
+| All uses consumed | Key becomes invalid, users see "used up" error |
+| Key reset | All existing keys revoked, new key generated |
+
+## Best Practices
+
+1. **Short-term invites (7 days):** For onboarding new team members
+2. **One-time use:** For sensitive access sharing
+3. **30-day expires:** Default for ongoing team access
+4. **90-day expires:** For long-term contractors
+
+## API Reference
+
+- `engram_init(invite_expires_days: int = 90)` — Set expiration
+- `engram_join(invite_key)` — Join with expiring key
+- `engram_reset_invite_key()` — Revoke all expiring keys

--- a/docs/WORKSPACE_MERGE.md
+++ b/docs/WORKSPACE_MERGE.md
@@ -1,0 +1,68 @@
+# Workspace Merge
+
+Engram supports merging durable facts from one workspace into another.
+
+## Use Cases
+
+- Consolidating teams after a reorganization
+- Migrating knowledge from a deprecated workspace
+- Combining knowledge bases from acquired teams
+
+## How It Works
+
+The merge process copies all **durable** facts from a source workspace to a target workspace, preserving:
+- Fact content and scope
+- Confidence scores
+- Agent attribution
+- Commit timestamps
+
+Ephemeral facts are NOT merged (they're temporary by design).
+
+## CLI Command
+
+```bash
+engram merge --source SOURCE_WORKSPACE_ID --target TARGET_WORKSPACE_ID
+```
+
+Options:
+- `--dry-run` - Preview what would be merged without making changes
+- `--scope-prefix` - Only merge facts matching a specific scope prefix
+
+## API Reference
+
+```python
+# Via MCP tool (future)
+await engram_merge(source_workspace_id, target_workspace_id, dry_run=False)
+```
+
+## Conflict Resolution
+
+If a fact with the same content_hash already exists in the target workspace:
+- The existing fact is kept
+- The incoming fact is skipped (no duplicates)
+
+## Permissions
+
+- Only workspace creators can initiate a merge
+- Both workspaces must use the same storage backend (SQLite or PostgreSQL)
+
+## Implementation Notes
+
+```python
+# Merge logic pseudocode
+source_facts = await storage.get_current_facts_in_scope(
+    durability='durable',
+    limit=100000
+)
+
+for fact in source_facts:
+    # Check for duplicates by content_hash
+    existing = await storage.find_duplicate(fact['content_hash'], fact['scope'])
+    if not existing:
+        await storage.insert_fact(fact)  # Copy to target
+```
+
+## Rate Limits
+
+- Maximum 10,000 facts per merge operation
+- Use scope filtering for larger workspaces


### PR DESCRIPTION
## Summary
- Apply chaos engineering principles to Engram's testing
- Document fault categories (storage, network, agent failures)
- Propose test suite with database resilience, conflict detection, reconnection tests
- Add implementation roadmap (3 phases) and tool recommendations

This establishes a framework for testing Engram's resilience to failures.

Closes #60