### PR TITLE
Add VS Code Agent Mode MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Your agent handles the rest.
 Engram is currently optimized for MCP-native workflows in:
 
 - [Claude Code](./docs/quickstart/claude-code.md)
+- [VS Code (Copilot)](./docs/quickstart/vscode-copilot.md)
 - [Windsurf](./docs/quickstart/windsurf.md)
 - [Zed](./docs/quickstart/zed.md)
 

--- a/docs/SUPPORTED_IDES.md
+++ b/docs/SUPPORTED_IDES.md
@@ -11,7 +11,7 @@ By default, the installer writes `https://mcp.engram.app/mcp` into each MCP conf
 | **Claude Code** | `~/.claude.json` | `mcpServers.{type: "http", url}` | CLI agent by Anthropic |
 | **Claude Desktop** | `claude_desktop_config.json` | `npx mcp-remote` stdio bridge | No native remote URL support; installer uses [mcp-remote](https://www.npmjs.com/package/mcp-remote) as a bridge. Requires Node.js/npx. |
 | **Cursor** | `~/.cursor/mcp.json` | `mcpServers.{url}` | VS Code fork by Anysphere |
-| **VS Code** | `<User>/mcp.json` | `servers.{type: "http", url}` | Requires GitHub Copilot extension for MCP |
+| **VS Code Agent Mode** | `Code/User/mcp.json` | `servers.{type: "http", url}` | Requires GitHub Copilot with Agent Mode |
 | **Windsurf** | `~/.codeium/windsurf/mcp_config.json` | `mcpServers.{serverUrl}` | Uses `serverUrl` key, not `url` |
 | **Kiro** | `~/.kiro/settings/mcp.json` | `mcpServers.{url}` | By AWS |
 | **Zed** | `settings.json` | `context_servers.{url}` | Rust-based editor; uses `context_servers` key |
@@ -87,7 +87,7 @@ After installation:
 1. Restart or reload your IDE if it was already open.
 2. Confirm that Engram was added to the IDE's MCP config file:
    - Cursor: `~/.cursor/mcp.json`
-   - VS Code: `<User>/mcp.json`
+   - VS Code Agent Mode: `Code/User/mcp.json`
    - Claude Code: `~/.claude.json`
 3. Open your IDE's MCP or tools UI, if available, and confirm the Engram server appears and is enabled.
 4. If you are joining an existing workspace, use your invite key during install.
@@ -121,9 +121,8 @@ If you install with `--join`, the final line will instead look like:
 
 ### VS Code
 **Common failure:** VS Code uses `servers.engram`, not `mcpServers.engram`.  
-**Fix:** Confirm Engram was written under `servers` in `<User>/mcp.json`, then restart VS Code.
+**Fix:** Confirm Engram was written under `servers` in `Code/User/mcp.json`, then restart VS Code and approve the MCP server trust prompt if shown.
 
 ### Claude Code
 **Common failure:** Claude Code and Claude Desktop use different config files and setup methods.  
 **Fix:** Check `~/.claude.json`, confirm Engram is listed under `mcpServers.engram`, then restart Claude Code.
-

--- a/docs/quickstart/vscode-copilot.md
+++ b/docs/quickstart/vscode-copilot.md
@@ -1,6 +1,7 @@
-# VS Code (Copilot) Quickstart
+# VS Code Agent Mode (GitHub Copilot) Quickstart
 
-VS Code requires GitHub Copilot extension for MCP support.
+VS Code Agent Mode supports MCP servers through GitHub Copilot. Engram works as a
+remote HTTP MCP server and does not require a local stdio bridge for VS Code.
 
 ## Setup
 
@@ -11,8 +12,10 @@ curl -fsSL https://engram-memory.com/install | sh
 
 ### Option 2: Manual Setup
 
-1. Create or edit `~/Library/Application Support/Code/User/mcp.json` (macOS)
-   or `~/.config/Code/User/mcp.json` (Linux):
+1. Create or edit your VS Code user-profile `mcp.json`:
+   - macOS: `~/Library/Application Support/Code/User/mcp.json`
+   - Linux: `~/.config/Code/User/mcp.json`
+   - Windows: `%APPDATA%\Code\User\mcp.json`
 
 ```json
 {
@@ -24,6 +27,9 @@ curl -fsSL https://engram-memory.com/install | sh
   }
 }
 ```
+
+VS Code also supports workspace MCP config at `.vscode/mcp.json`. Use the user-profile
+file for Engram if you want it available across all workspaces.
 
 For local development:
 ```json
@@ -39,10 +45,12 @@ For local development:
 
 2. Restart VS Code
 3. Ensure GitHub Copilot extension is installed
+4. If VS Code prompts you to trust the MCP server, approve Engram after reviewing the
+   server URL.
 
 ## First Time Setup
 
-1. Open a new chat (Ctrl+Shift+P → "Copilot: Chat")
+1. Open Chat in Agent Mode.
 2. Tell it: `"Set up Engram for my team"` to create a workspace
 3. Or: `"Join Engram with key ek_live_..."` to join existing workspace
 
@@ -66,10 +74,22 @@ Expected output:
 {"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
 ```
 
+## Compatibility Notes
+
+- VS Code expects MCP servers under the top-level `servers` key, not `mcpServers`.
+- Remote Engram uses `"type": "http"` with the `/mcp` URL.
+- Opening `https://mcp.engram.app/mcp` in a browser is not a reliable test; verify from
+  VS Code's MCP server list or by asking Agent Mode to call `engram_status`.
+- Workspace config at `.vscode/mcp.json` is useful for shared project setup, but user
+  config is better for the installer because it follows the developer across repos.
+
 ## Troubleshooting
 
 - Ensure GitHub Copilot is active
+- Confirm Agent Mode is enabled in Chat
 - Check MCP config path matches your OS
+- Confirm the Engram entry is under `servers.engram`
 - Restart VS Code after config changes
+- Use VS Code's MCP output log if the server appears but does not start
 
 See [docs/TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for more help.

--- a/src/data/cli-agent-clients.json
+++ b/src/data/cli-agent-clients.json
@@ -364,25 +364,25 @@
         }
     },
     "VS Code (Copilot)": {
-        "path": ".vscode/mcp.json",
-        "server_type_key": "mcpServers",
+        "path": "Code/User/mcp.json",
+        "server_type_key": "servers",
         "family": "VS Code",
         "config_path": {
-            "appdata": false,
-            "appsupport": false,
-            "xdg": false,
-            "syshome": true
+            "appdata": true,
+            "appsupport": true,
+            "xdg": true,
+            "syshome": false
         }
     },
     "VS Code Insiders (Copilot)": {
-        "path": ".vscode-insiders/mcp.json",
-        "server_type_key": "mcpServers",
+        "path": "Code - Insiders/User/mcp.json",
+        "server_type_key": "servers",
         "family": "VS Code",
         "config_path": {
-            "appdata": false,
-            "appsupport": false,
-            "xdg": false,
-            "syshome": true
+            "appdata": true,
+            "appsupport": true,
+            "xdg": true,
+            "syshome": false
         }
     },
     "Warp": {

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -16,6 +16,7 @@ import logging
 import sys
 from pathlib import Path
 import os
+import platform
 
 import click
 
@@ -25,7 +26,11 @@ from engram.storage import DEFAULT_DB_PATH
 _DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 _PATH_SYSTEM_HOME = Path.home()
 _PATH_APPDATA_DIR = Path(os.environ["APPDATA"]) if "APPDATA" in os.environ else None
-_PATH_APPSUPPORT_DIR = _PATH_SYSTEM_HOME / "Library" / "Application Support"  # Mac only
+_PATH_APPSUPPORT_DIR = (
+    _PATH_SYSTEM_HOME / "Library" / "Application Support"
+    if platform.system() == "Darwin"
+    else None
+)
 _PATH_XDG_DIR = (
     Path(os.environ["XDG_CONFIG_HOME"])
     if "XDG_CONFIG_HOME" in os.environ
@@ -78,6 +83,9 @@ def _engram_mcp_entry_for_client(client_name: str) -> dict[str, object]:
 
     if client_name == "Zed":
         return {"url": mcp_url}
+
+    if client_name.startswith("VS Code"):
+        return {"type": "http", "url": mcp_url}
 
     return {
         "command": "uvx",

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -71,3 +71,33 @@ def test_install_writes_zed_context_server_url(tmp_path, monkeypatch):
         assert "context_servers" in data
         assert "engram" in data["context_servers"]
         assert data["context_servers"]["engram"] == {"url": "https://mcp.engram.app/mcp"}
+
+
+def test_install_writes_vscode_copilot_http_server(tmp_path, monkeypatch):
+    runner = CliRunner()
+    workspace_path = tmp_path / ".engram" / "workspace.json"
+
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://mcp.engram.app/mcp")
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+        patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+    ):
+        config_path = (
+            tmp_path / "Library" / "Application Support" / "Code" / "User" / "mcp.json"
+        )
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text("{}")
+
+        result = runner.invoke(main, ["install"])
+
+        assert result.exit_code == 0
+
+        data = json.loads(config_path.read_text())
+        assert "servers" in data
+        assert "engram" in data["servers"]
+        assert data["servers"]["engram"] == {
+            "type": "http",
+            "url": "https://mcp.engram.app/mcp",
+        }

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -237,6 +237,43 @@ class TestVerifyCommand:
         assert "✓" in result.output
         assert "Zed" in result.output
 
+    def test_verify_detects_vscode_copilot_servers_config(self, cli_runner, temp_home):
+        """Test verify detects VS Code Agent Mode's servers.engram config shape."""
+        workspace_dir = temp_home / ".engram"
+        workspace_dir.mkdir(parents=True)
+        workspace_file = workspace_dir / "workspace.json"
+        workspace_file.write_text(
+            json.dumps(
+                {
+                    "engram_id": "ENG-TEST-1234",
+                    "db_url": "",
+                    "schema": "engram",
+                }
+            )
+        )
+
+        vscode_dir = temp_home / "Library" / "Application Support" / "Code" / "User"
+        vscode_dir.mkdir(parents=True)
+        (vscode_dir / "mcp.json").write_text(
+            json.dumps(
+                {
+                    "servers": {
+                        "engram": {
+                            "type": "http",
+                            "url": "https://mcp.engram.app/mcp",
+                        }
+                    }
+                }
+            )
+        )
+
+        with patch("pathlib.Path.home", return_value=temp_home):
+            result = cli_runner.invoke(main, ["verify"])
+
+        assert result.exit_code == 0
+        assert "✓" in result.output
+        assert "VS Code (Copilot)" in result.output
+
     def test_verify_verbose_flag(self, cli_runner, temp_home):
         """Test verify with --verbose flag shows additional details."""
         # Create workspace
@@ -439,10 +476,19 @@ class TestVerifyMCPClientDetection:
         )
 
         # VS Code
-        vscode_dir = temp_home / ".vscode"
+        vscode_dir = temp_home / "Library" / "Application Support" / "Code" / "User"
         vscode_dir.mkdir(parents=True)
         (vscode_dir / "mcp.json").write_text(
-            json.dumps({"mcpServers": {"engram": {"command": "uvx"}}})
+            json.dumps(
+                {
+                    "servers": {
+                        "engram": {
+                            "type": "http",
+                            "url": "https://mcp.engram.app/mcp",
+                        }
+                    }
+                }
+            )
         )
 
         with patch("pathlib.Path.home", return_value=temp_home):


### PR DESCRIPTION
## Summary

Adds VS Code / GitHub Copilot Agent Mode MCP support across Engram install, verify/doctor detection, and docs.

## What changed

- updated VS Code installer metadata and config paths in `src/data/cli-agent-clients.json`
  - VS Code now uses `Code/User/mcp.json`
  - VS Code Insiders now uses `Code - Insiders/User/mcp.json`
  - both use top-level `servers`, not `mcpServers`
- updated the CLI MCP entry builder in `src/engram/cli.py` so VS Code writes:
  ```json
  {
    "type": "http",
    "url": "https://mcp.engram.app/mcp"
  }