### PR TITLE
Automated_Invite-Key_Expiry_&_Rotation_Workflow_N01

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ All source lives under `src/engram/`.
 | Module | Purpose |
 |--------|---------|
 | `server.py` | MCP server (FastMCP) with 15 tools — the I/O layer |
-| `engine.py` | Core memory engine: commit pipeline, conflict detection (5-tier async), GDPR erasure |
+| `engine.py` | Core memory engine: commit pipeline, conflict detection (5-tier async), GDPR erasure, invite key rotation |
 | `storage.py` | SQLite backend (async, WAL mode, FTS5) |
 | `postgres_storage.py` | PostgreSQL backend (pgvector, tsvector, TIMESTAMPTZ) |
 | `schema.py` | Database schema definitions and migrations (currently v10) |
@@ -50,7 +50,7 @@ All source lives under `src/engram/`.
 
 ## Schema Version Invariant
 
-- Database schema version is tracked in `src/engram/schema.py` (currently **v10**)
+- Database schema version is tracked in `src/engram/schema.py` (currently **v11**)
 - When adding new tables or columns, increment `SCHEMA_VERSION` and add a migration entry
 - Document the migration path in `docs/MIGRATION_SCHEMA.md`
 
@@ -87,6 +87,7 @@ All source lives under `src/engram/`.
 
 **Compliance:**
 - `engram_gdpr_erase` — GDPR right-to-erasure for an agent (founder only; soft or hard mode)
+- `engram_reset_invite_key` — now accepts `grace_minutes` (default 15) and `reason` params; fires `invite_key.rotated` webhook event and writes audit log entry
 
 ## Rules
 
@@ -111,5 +112,5 @@ All source lives under `src/engram/`.
 - `AGENTS.md` — Universal AI assistant guidance
 - `HIRING.md` — Paid contract opportunities ($125-185/hour)
 - `docs/IMPLEMENTATION.md` — Architecture and phase delivery plan
-- `docs/MIGRATION_SCHEMA.md` — Database migration guide
-- `docs/PRIVACY_ARCHITECTURE.md` — GDPR erasure, anonymous mode, zero-knowledge design
+- `docs/MIGRATION_SCHEMA.md` — Database migration guide (current: v11)
+- `docs/PRIVACY_ARCHITECTURE.md` — GDPR erasure, anonymous mode, zero-knowledge design, invite key lifecycle

--- a/docs/MIGRATION_SCHEMA.md
+++ b/docs/MIGRATION_SCHEMA.md
@@ -347,6 +347,7 @@ If you encounter issues:
 | v8 | `webhooks`, `webhook_deliveries`, `resolution_rules`, `scopes`, `audit_log` |
 | v9 | `display_name`, `description` on workspaces |
 | v10 | SQLite `facts_au` AFTER UPDATE trigger (FTS5 consistency for GDPR hard-erase) |
+| v11 | `revoked_at`, `grace_until`, `rotation_reason` on `invite_keys`; grace index |
 
 ## Schema v10 — GDPR FTS Update Trigger
 
@@ -375,9 +376,50 @@ CREATE TRIGGER IF NOT EXISTS facts_au
     END;
 ```
 
+## Schema v11 — Invite Key Lifecycle
+
+**Purpose:** Support soft-revocation with a configurable grace period for
+invite key rotation, plus an audit trail and structured rotation metadata.
+
+**New columns on `invite_keys`:**
+
+| Column | Type (SQLite / Postgres) | Meaning |
+|--------|--------------------------|---------|
+| `revoked_at` | `TEXT` / `TIMESTAMPTZ` | When the key was soft-revoked; `NULL` = still active |
+| `grace_until` | `TEXT` / `TIMESTAMPTZ` | Existing sessions may continue until this timestamp |
+| `rotation_reason` | `TEXT` | Optional operator note stored at revocation time |
+
+**New index:** `invite_keys_grace ON invite_keys(engram_id, grace_until)` —
+enables efficient `get_active_grace_until` queries.
+
+**SQLite migration SQL (runs automatically on next `connect()`):**
+
+```sql
+ALTER TABLE invite_keys ADD COLUMN revoked_at TEXT;
+ALTER TABLE invite_keys ADD COLUMN grace_until TEXT;
+ALTER TABLE invite_keys ADD COLUMN rotation_reason TEXT;
+CREATE INDEX IF NOT EXISTS invite_keys_grace ON invite_keys(engram_id, grace_until);
+```
+
+**PostgreSQL migration SQL (runs automatically on next `connect()`):**
+
+```sql
+ALTER TABLE invite_keys ADD COLUMN revoked_at TIMESTAMPTZ;
+ALTER TABLE invite_keys ADD COLUMN grace_until TIMESTAMPTZ;
+ALTER TABLE invite_keys ADD COLUMN rotation_reason TEXT;
+CREATE INDEX IF NOT EXISTS invite_keys_grace ON invite_keys(engram_id, grace_until);
+```
+
+**Behaviour change:** `consume_invite_key` and `validate_invite_key` now
+add `AND revoked_at IS NULL` to their `WHERE` clause.  Revoked keys cannot
+be used for new joins even when still within their grace window.
+
+See [PRIVACY_ARCHITECTURE.md — Invite Key Lifecycle](./PRIVACY_ARCHITECTURE.md)
+for the full rotation workflow and grace period semantics.
+
 ## Related Documentation
 
-- [PRIVACY_ARCHITECTURE.md](./PRIVACY_ARCHITECTURE.md) - GDPR erasure workflow
+- [PRIVACY_ARCHITECTURE.md](./PRIVACY_ARCHITECTURE.md) - GDPR erasure and invite key lifecycle
 - [DATABASE_SECURITY.md](./DATABASE_SECURITY.md) - Security features
 - [IMPLEMENTATION.md](./IMPLEMENTATION.md) - Technical details
 - [README.md](../README.md) - Quick start guide

--- a/docs/PRIVACY_ARCHITECTURE.md
+++ b/docs/PRIVACY_ARCHITECTURE.md
@@ -326,6 +326,89 @@ in `~/.engram/workspace.json`).  A `PermissionError` / 403 is returned for all o
    for your own compliance audit trail — Engram's audit log entry is also
    scrubbed during erasure.
 
+## Invite Key Lifecycle
+
+Engram workspace access is controlled by cryptographic invite keys. Every key
+embeds the workspace ID, database URL, and a key generation counter in an
+HMAC-signed, XOR-encrypted payload. Key rotation is the primary mechanism for
+revoking access.
+
+### Key rotation flow
+
+1. Creator calls `engram_reset_invite_key` (MCP), `POST /api/invite-key/rotate`
+   (REST), or `engram invite rotate` (CLI).
+2. All **active** invite keys are **soft-revoked**: `revoked_at` is set to now,
+   `grace_until` is set to `now + grace_minutes` (default 15 minutes).
+3. The workspace `key_generation` counter is incremented.
+4. A new invite key is generated with the updated generation counter and
+   stored in the database.
+5. An audit log entry (`operation = key_rotation`) is written with the old and
+   new generations, grace window, reason, and actor.
+6. A `invite_key.rotated` webhook event is fired to all subscribed endpoints.
+
+### Grace period for active sessions
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Within grace window | Existing sessions continue uninterrupted |
+| Grace window expired | Agent receives `"disconnected"` on next tool call |
+| New join attempt with old key | **Rejected immediately** (grace does not apply) |
+
+The grace window allows agents currently in the middle of a long task to
+finish before being disconnected. It provides **no protection** for new
+join attempts — `consume_invite_key` checks `revoked_at IS NULL` and returns
+`None` for revoked keys regardless of `grace_until`.
+
+To revoke access immediately with no grace period, use `grace_minutes=0`.
+
+### Audit trail
+
+Every rotation produces an `audit_log` row:
+
+```json
+{
+  "operation": "key_rotation",
+  "extra": {
+    "old_generation": 2,
+    "new_generation": 3,
+    "grace_minutes": 15,
+    "grace_until": "2026-04-13T02:30:00+00:00",
+    "reason": "Suspected credential leak",
+    "actor": "alice"
+  }
+}
+```
+
+Query rotation history via `engram invite history` (CLI) or
+`GET /api/invite-key/history` (REST).
+
+### Webhook payload (`invite_key.rotated`)
+
+```json
+{
+  "event": "invite_key.rotated",
+  "data": {
+    "workspace_id": "ENG-XXXX-YYYY",
+    "old_generation": 2,
+    "new_generation": 3,
+    "rotated_by": "alice",
+    "grace_until": "2026-04-13T02:30:00+00:00",
+    "reason": "Suspected credential leak"
+  }
+}
+```
+
+Subscribe to this event by registering a webhook with `"invite_key.rotated"` in
+the `events` list, or use `"*"` to receive all events.
+
+### Operator checklist for key rotation
+
+1. Notify team members beforehand if using `grace_minutes=0` (no grace).
+2. Set a meaningful `reason` — it appears in the audit log and rotation history.
+3. Distribute the new invite key via a secure out-of-band channel.
+4. Confirm all agents have reconnected by checking `GET /api/agents`.
+5. Rotate quarterly as a preventive measure, not only after suspected breaches.
+
 ## Related Documentation
 
 - [DATABASE_SECURITY.md](./DATABASE_SECURITY.md) - Database configuration and isolation

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1859,7 +1859,9 @@ def invite_rotate(
 
         db_url = ws.db_url
         if not db_url:
-            raise click.ClickException("No team database configured. Key rotation requires team mode.")
+            raise click.ClickException(
+                "No team database configured. Key rotation requires team mode."
+            )
 
         if db_url.startswith("postgres"):
             from engram.postgres_storage import PostgresStorage
@@ -1954,7 +1956,9 @@ def invite_history(limit: int) -> None:
                     extra = json.loads(extra)
                 except Exception:
                     extra = {}
-            click.echo(f"  {entry.get('timestamp', 'unknown')} — generation {extra.get('old_generation', '?')} → {extra.get('new_generation', '?')}")
+            click.echo(
+                f"  {entry.get('timestamp', 'unknown')} — generation {extra.get('old_generation', '?')} → {extra.get('new_generation', '?')}"
+            )
             if extra.get("reason"):
                 click.echo(f"    reason  : {extra['reason']}")
             click.echo(f"    actor   : {extra.get('actor', 'unknown')}")

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1781,5 +1781,189 @@ def gdpr_erase(agent_id: str, mode: str, yes: bool) -> None:
         raise click.ClickException(f"Erasure failed: {exc}")
 
 
+# ── engram invite ────────────────────────────────────────────────────
+
+
+@main.group()
+def invite() -> None:
+    """Invite key lifecycle commands (workspace creator only)."""
+    pass
+
+
+@invite.command("rotate")
+@click.option(
+    "--grace-minutes",
+    default=15,
+    show_default=True,
+    help="Grace window (minutes) for active sessions after rotation. 0 = immediate revocation.",
+)
+@click.option(
+    "--reason",
+    default="",
+    help="Optional note explaining why the key was rotated (stored in audit log).",
+)
+@click.option(
+    "--expires-days",
+    default=90,
+    show_default=True,
+    help="Validity period in days for the new invite key.",
+)
+@click.option(
+    "--uses",
+    default=10,
+    show_default=True,
+    help="Max number of times the new invite key can be consumed.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip interactive confirmation (for non-interactive / scripted use).",
+)
+def invite_rotate(
+    grace_minutes: int,
+    reason: str,
+    expires_days: int,
+    uses: int,
+    yes: bool,
+) -> None:
+    """Rotate the workspace invite key with audit trail and webhook notification.
+
+    Soft-revokes all existing keys with an optional grace period so agents
+    in active sessions can finish their work before being disconnected.
+    New join attempts with the old key are rejected immediately.
+
+    Requires the local workspace to be initialised as a creator workspace.
+    """
+    import asyncio
+
+    if not yes:
+        click.echo("\nAbout to rotate the workspace invite key.")
+        if grace_minutes > 0:
+            click.echo(f"  Grace period : {grace_minutes} minutes for active sessions")
+        else:
+            click.echo("  Grace period : none (immediate revocation)")
+        if reason:
+            click.echo(f"  Reason       : {reason}")
+        click.confirm("Proceed?", abort=True)
+
+    async def _run() -> None:
+        from engram.engine import EngramEngine
+        from engram.workspace import read_workspace
+
+        ws = read_workspace()
+        if ws is None:
+            raise click.ClickException("No workspace configured. Run 'engram setup' first.")
+        if not ws.is_creator:
+            raise click.ClickException("Key rotation is restricted to the workspace creator.")
+
+        db_url = ws.db_url
+        if not db_url:
+            raise click.ClickException("No team database configured. Key rotation requires team mode.")
+
+        if db_url.startswith("postgres"):
+            from engram.postgres_storage import PostgresStorage
+
+            storage = PostgresStorage(db_url, workspace_id=ws.engram_id, schema=ws.schema)
+        else:
+            from engram.storage import SQLiteStorage
+
+            storage = SQLiteStorage(workspace_id=ws.engram_id)
+
+        await storage.connect()
+        try:
+            engine = EngramEngine(storage)
+            result = await engine.rotate_invite_key(
+                expires_days=expires_days,
+                uses=uses,
+                grace_minutes=grace_minutes,
+                reason=reason or None,
+                actor="cli",
+            )
+        except PermissionError as exc:
+            raise click.ClickException(str(exc)) from exc
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        finally:
+            await storage.close()
+
+        click.echo("\nInvite key rotated successfully.")
+        click.echo(f"  Old generation : {result['old_generation']}")
+        click.echo(f"  New generation : {result['new_generation']}")
+        if result.get("grace_until"):
+            click.echo(f"  Grace until    : {result['grace_until']}")
+        click.echo(f"\nNew invite key:\n\n  {result['invite_key']}\n")
+        click.echo("Share this key with your team via a secure channel.")
+
+    try:
+        asyncio.run(_run())
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(f"Key rotation failed: {exc}")
+
+
+@invite.command("history")
+@click.option(
+    "--limit",
+    default=20,
+    show_default=True,
+    help="Maximum number of rotation audit entries to display.",
+)
+def invite_history(limit: int) -> None:
+    """Show the invite key rotation audit trail for this workspace."""
+    import asyncio
+
+    async def _run() -> None:
+        from engram.engine import EngramEngine
+        from engram.workspace import read_workspace
+
+        ws = read_workspace()
+        if ws is None:
+            raise click.ClickException("No workspace configured. Run 'engram setup' first.")
+
+        db_url = ws.db_url
+        if not db_url:
+            raise click.ClickException("No team database configured. History requires team mode.")
+
+        if db_url.startswith("postgres"):
+            from engram.postgres_storage import PostgresStorage
+
+            storage = PostgresStorage(db_url, workspace_id=ws.engram_id, schema=ws.schema)
+        else:
+            from engram.storage import SQLiteStorage
+
+            storage = SQLiteStorage(workspace_id=ws.engram_id)
+
+        await storage.connect()
+        engine = EngramEngine(storage)
+        try:
+            entries = await engine.get_rotation_history(limit=limit)
+        finally:
+            await storage.close()
+
+        if not entries:
+            click.echo("No key rotation events found.")
+            return
+
+        click.echo(f"\nKey rotation history ({len(entries)} entries):\n")
+        for entry in entries:
+            extra = entry.get("extra") or "{}"
+            if isinstance(extra, str):
+                try:
+                    extra = json.loads(extra)
+                except Exception:
+                    extra = {}
+            click.echo(f"  {entry.get('timestamp', 'unknown')} — generation {extra.get('old_generation', '?')} → {extra.get('new_generation', '?')}")
+            if extra.get("reason"):
+                click.echo(f"    reason  : {extra['reason']}")
+            click.echo(f"    actor   : {extra.get('actor', 'unknown')}")
+            grace = extra.get("grace_until") or extra.get("grace_minutes")
+            if grace:
+                click.echo(f"    grace   : {grace}")
+
+    asyncio.run(_run())
+
+
 if __name__ == "__main__":
     main()

--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -2586,9 +2586,7 @@ class EngramEngine:
         if ws is None:
             return []
         engram_id = ws.engram_id if ws.db_url else "local"
-        return await self.storage.get_key_rotation_history(
-            engram_id, limit=max(1, min(limit, 200))
-        )
+        return await self.storage.get_key_rotation_history(engram_id, limit=max(1, min(limit, 200)))
 
     # ── GDPR subject erasure ─────────────────────────────────────────
 

--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -2424,6 +2424,172 @@ class EngramEngine:
             limit=limit,
         )
 
+    # ── Invite key lifecycle ─────────────────────────────────────────
+
+    async def rotate_invite_key(
+        self,
+        *,
+        expires_days: int = 90,
+        uses: int = 10,
+        grace_minutes: int = 15,
+        reason: str | None = None,
+        actor: str | None = None,
+    ) -> dict[str, Any]:
+        """Rotate the workspace invite key with audit trail and webhook notification.
+
+        Soft-revokes all active keys (with an optional grace period so agents
+        mid-session can finish their work), bumps the workspace key generation,
+        generates a fresh invite key, and fires an ``invite_key.rotated`` webhook
+        event for downstream consumers.
+
+        Args:
+            expires_days: Validity period for the new key in days (default 90).
+            uses: Maximum number of times the new key can be consumed (default 10).
+            grace_minutes: How long revoked keys remain valid for *existing* sessions
+                (not new joins). 0 = immediate revocation (default 15).
+            reason: Optional human-readable reason stored in the audit log.
+            actor: Identity of the person triggering the rotation (for audit).
+
+        Returns:
+            dict with ``invite_key``, ``new_generation``, ``old_generation``,
+            and ``grace_until`` (ISO string or None).
+
+        Raises:
+            ValueError: If the workspace is not in team mode.
+            PermissionError: If the caller is not the workspace creator.
+        """
+        import time
+
+        from engram.workspace import (
+            WorkspaceConfig,
+            generate_invite_key,
+            read_workspace,
+            write_workspace,
+        )
+
+        ws = read_workspace()
+        if ws is None or not ws.db_url:
+            raise ValueError(
+                "No team workspace configured. rotate_invite_key is only usable in team mode."
+            )
+        if not ws.is_creator:
+            raise PermissionError(
+                "Invite key rotation is restricted to the workspace creator. "
+                "Only the founder who ran engram_init may perform this operation."
+            )
+
+        old_gen = ws.key_generation
+
+        # Soft-revoke all active keys (existing sessions continue during grace period).
+        await self.storage.revoke_all_invite_keys(
+            ws.engram_id, grace_minutes=grace_minutes, reason=reason
+        )
+
+        # Bump the generation counter — this is what _check_key_generation observes.
+        new_gen = await self.storage.bump_key_generation(ws.engram_id)
+
+        # Generate and store the new invite key.
+        invite_key, key_hash = generate_invite_key(
+            db_url=ws.db_url,
+            engram_id=ws.engram_id,
+            expires_days=expires_days,
+            uses_remaining=uses,
+            schema=ws.schema,
+            key_generation=new_gen,
+        )
+        expires_ts = datetime.fromtimestamp(
+            time.time() + expires_days * 86400, tz=timezone.utc
+        ).isoformat()
+        await self.storage.insert_invite_key(
+            key_hash=key_hash,
+            engram_id=ws.engram_id,
+            expires_at=expires_ts,
+            uses_remaining=uses,
+        )
+
+        # Persist updated generation to local workspace.json.
+        updated_config = WorkspaceConfig(
+            engram_id=ws.engram_id,
+            db_url=ws.db_url,
+            schema=ws.schema,
+            anonymous_mode=ws.anonymous_mode,
+            anon_agents=ws.anon_agents,
+            key_generation=new_gen,
+            is_creator=True,
+        )
+        write_workspace(updated_config)
+
+        grace_until: str | None = None
+        if grace_minutes > 0:
+            from datetime import timedelta
+
+            grace_until = (
+                datetime.now(timezone.utc) + timedelta(minutes=grace_minutes)
+            ).isoformat()
+
+        # Audit log entry — no PII.
+        import json as _json
+
+        await self._audit(
+            "key_rotation",
+            extra=_json.dumps(
+                {
+                    "old_generation": old_gen,
+                    "new_generation": new_gen,
+                    "grace_minutes": grace_minutes,
+                    "grace_until": grace_until,
+                    "reason": reason or "",
+                    "actor": actor or "unknown",
+                }
+            ),
+        )
+
+        # Webhook notification via existing delivery worker.
+        asyncio.ensure_future(
+            self._fire_event(
+                "invite_key.rotated",
+                {
+                    "workspace_id": ws.engram_id,
+                    "old_generation": old_gen,
+                    "new_generation": new_gen,
+                    "rotated_by": actor or "unknown",
+                    "grace_until": grace_until,
+                    "reason": reason or "",
+                },
+            )
+        )
+
+        logger.warning(
+            "Invite key rotated: workspace=%s old_gen=%d new_gen=%d grace_minutes=%d actor=%s",
+            ws.engram_id,
+            old_gen,
+            new_gen,
+            grace_minutes,
+            actor or "unknown",
+        )
+
+        return {
+            "invite_key": invite_key,
+            "old_generation": old_gen,
+            "new_generation": new_gen,
+            "grace_until": grace_until,
+        }
+
+    async def get_rotation_history(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Return invite key rotation audit entries for this workspace.
+
+        Ordered most-recent first. Capped at 200 entries.
+        """
+        from engram.workspace import read_workspace
+
+        ws = read_workspace()
+        if ws is None:
+            return []
+        engram_id = ws.engram_id if ws.db_url else "local"
+        return await self.storage.get_key_rotation_history(
+            engram_id, limit=max(1, min(limit, 200))
+        )
+
     # ── GDPR subject erasure ─────────────────────────────────────────
 
     async def gdpr_erase_agent(

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -1143,9 +1143,7 @@ class PostgresStorage(BaseStorage):
             )
         return int(result.split()[-1])
 
-    async def get_key_rotation_history(
-        self, engram_id: str, limit: int = 20
-    ) -> list[dict]:
+    async def get_key_rotation_history(self, engram_id: str, limit: int = 20) -> list[dict]:
         async with self.acquire() as conn:
             rows = await conn.fetch(
                 "SELECT * FROM audit_log "

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -1071,6 +1071,7 @@ class PostgresStorage(BaseStorage):
                 "WHERE key_hash = $1 "
                 "AND (expires_at IS NULL OR expires_at > NOW()) "
                 "AND (uses_remaining IS NULL OR uses_remaining > 0) "
+                "AND revoked_at IS NULL "
                 "RETURNING *",
                 key_hash,
             )
@@ -1092,9 +1093,128 @@ class PostgresStorage(BaseStorage):
             )
         return row["key_generation"] if row else 0
 
-    async def revoke_all_invite_keys(self, engram_id: str) -> None:
+    async def revoke_all_invite_keys(
+        self,
+        engram_id: str,
+        *,
+        grace_minutes: int = 15,
+        reason: str | None = None,
+    ) -> None:
         async with self.acquire() as conn:
-            await conn.execute("DELETE FROM invite_keys WHERE engram_id = $1", engram_id)
+            # Purge already-expired grace keys as a side-effect.
+            await conn.execute(
+                "DELETE FROM invite_keys WHERE engram_id = $1 AND revoked_at IS NOT NULL AND grace_until < NOW()",
+                engram_id,
+            )
+            if grace_minutes > 0:
+                await conn.execute(
+                    "UPDATE invite_keys "
+                    "SET revoked_at = NOW(), "
+                    "    grace_until = NOW() + ($2 || ' minutes')::INTERVAL, "
+                    "    rotation_reason = $3 "
+                    "WHERE engram_id = $1 AND revoked_at IS NULL",
+                    engram_id,
+                    str(grace_minutes),
+                    reason,
+                )
+            else:
+                await conn.execute(
+                    "DELETE FROM invite_keys WHERE engram_id = $1 AND revoked_at IS NULL",
+                    engram_id,
+                )
+
+    async def get_active_grace_until(self, engram_id: str) -> str | None:
+        async with self.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT MAX(grace_until) AS grace_until FROM invite_keys "
+                "WHERE engram_id = $1 AND revoked_at IS NOT NULL AND grace_until > NOW()",
+                engram_id,
+            )
+        if row and row["grace_until"] is not None:
+            val = row["grace_until"]
+            return val.isoformat() if isinstance(val, datetime) else str(val)
+        return None
+
+    async def cleanup_expired_grace_keys(self, engram_id: str) -> int:
+        async with self.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM invite_keys WHERE engram_id = $1 AND revoked_at IS NOT NULL AND grace_until < NOW()",
+                engram_id,
+            )
+        return int(result.split()[-1])
+
+    async def get_key_rotation_history(
+        self, engram_id: str, limit: int = 20
+    ) -> list[dict]:
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM audit_log "
+                "WHERE operation = 'key_rotation' AND workspace_id = $1 "
+                "ORDER BY timestamp DESC LIMIT $2",
+                engram_id,
+                max(1, min(limit, 200)),
+            )
+        return [_row_to_dict(r) for r in rows]
+
+    async def insert_audit_entry(self, entry: dict[str, Any]) -> None:
+        import json as _json
+
+        extra = entry.get("extra")
+        if isinstance(extra, str):
+            try:
+                extra = _json.loads(extra)
+            except Exception:
+                extra = {"raw": extra}
+
+        async with self.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO audit_log(id, operation, agent_id, fact_id, conflict_id, extra, timestamp, workspace_id) "
+                "VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)",
+                entry["id"],
+                entry["operation"],
+                entry.get("agent_id"),
+                entry.get("fact_id"),
+                entry.get("conflict_id"),
+                _json.dumps(extra) if extra is not None else "{}",
+                entry.get("timestamp", _now_ts().isoformat()),
+                self.workspace_id,
+            )
+
+    async def get_audit_log(
+        self,
+        agent_id: str | None = None,
+        operation: str | None = None,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        conditions = ["workspace_id = $1"]
+        params: list[Any] = [self.workspace_id]
+        idx = 2
+        if agent_id:
+            conditions.append(f"agent_id = ${idx}")
+            params.append(agent_id)
+            idx += 1
+        if operation:
+            conditions.append(f"operation = ${idx}")
+            params.append(operation)
+            idx += 1
+        if from_ts:
+            conditions.append(f"timestamp >= ${idx}")
+            params.append(from_ts)
+            idx += 1
+        if to_ts:
+            conditions.append(f"timestamp <= ${idx}")
+            params.append(to_ts)
+            idx += 1
+        params.append(max(1, min(limit, 1000)))
+        sql = (
+            f"SELECT * FROM audit_log WHERE {' AND '.join(conditions)} "
+            f"ORDER BY timestamp DESC LIMIT ${idx}"
+        )
+        async with self.acquire() as conn:
+            rows = await conn.fetch(sql, *params)
+        return [_row_to_dict(r) for r in rows]
 
     async def get_invite_keys(self) -> list[dict]:
         """Return list of active invite keys."""

--- a/src/engram/rest.py
+++ b/src/engram/rest.py
@@ -883,7 +883,7 @@ def build_rest_routes(
 
         return JSONResponse(result)
 
-    async def api_invite_key_rotate(request: Request) -> Response:
+    async def api_invite_key_rotate(request: Request) -> JSONResponse:
         """POST /api/invite-key/rotate — rotate the workspace invite key.
 
         Body (JSON):
@@ -918,7 +918,7 @@ def build_rest_routes(
 
         return JSONResponse({"status": "rotated", **result})
 
-    async def api_invite_key_history(request: Request) -> Response:
+    async def api_invite_key_history(request: Request) -> JSONResponse:
         """GET /api/invite-key/history?limit=N — rotation audit trail.
 
         Returns a list of audit log entries for key_rotation events,

--- a/src/engram/rest.py
+++ b/src/engram/rest.py
@@ -883,6 +883,55 @@ def build_rest_routes(
 
         return JSONResponse(result)
 
+    async def api_invite_key_rotate(request: Request) -> Response:
+        """POST /api/invite-key/rotate — rotate the workspace invite key.
+
+        Body (JSON):
+            grace_minutes  int   optional, default 15  (0 = immediate revocation)
+            reason         str   optional note for the audit log
+            expires_days   int   optional, default 90
+            uses           int   optional, default 10
+
+        Returns {status, invite_key, new_generation, old_generation, grace_until}
+        Restricted to workspace creator.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+
+        try:
+            result = await engine.rotate_invite_key(
+                expires_days=int(body.get("expires_days", 90)),
+                uses=int(body.get("uses", 10)),
+                grace_minutes=int(body.get("grace_minutes", 15)),
+                reason=body.get("reason") or None,
+                actor=body.get("actor"),
+            )
+        except PermissionError as exc:
+            return _error(str(exc), status=403)
+        except ValueError as exc:
+            return _error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("REST /api/invite-key/rotate error")
+            return _error(str(exc), status=500)
+
+        return JSONResponse({"status": "rotated", **result})
+
+    async def api_invite_key_history(request: Request) -> Response:
+        """GET /api/invite-key/history?limit=N — rotation audit trail.
+
+        Returns a list of audit log entries for key_rotation events,
+        ordered most-recent first.
+        """
+        try:
+            limit = int(request.query_params.get("limit", "20"))
+        except ValueError:
+            limit = 20
+
+        entries = await engine.get_rotation_history(limit=limit)
+        return JSONResponse({"entries": entries, "count": len(entries)})
+
     return [
         Route("/api/commit", api_commit, methods=["POST"]),
         Route("/api/query", api_query, methods=["POST"]),
@@ -923,4 +972,7 @@ def build_rest_routes(
         Route("/api/audit", api_audit, methods=["GET"]),
         # GDPR
         Route("/api/gdpr/erase", api_gdpr_erase, methods=["POST"]),
+        # Invite key lifecycle
+        Route("/api/invite-key/rotate", api_invite_key_rotate, methods=["POST"]),
+        Route("/api/invite-key/history", api_invite_key_history, methods=["GET"]),
     ]

--- a/src/engram/schema.py
+++ b/src/engram/schema.py
@@ -9,12 +9,19 @@ Schema version 10 adds:
 - facts_au trigger for SQLite FTS5 consistency on content/keywords updates
   (required by the GDPR subject-erasure hard-erase path)
 
+Schema version 11 adds:
+- invite_keys.revoked_at: ISO timestamp of soft-revocation (NULL = active)
+- invite_keys.grace_until: ISO timestamp until which revoked keys still allow
+  existing sessions to continue (grace period for key rotation)
+- invite_keys.rotation_reason: optional human-readable reason for revocation
+- Index on (engram_id, grace_until) for efficient grace-period queries
+
 Two schemas are maintained:
 - SCHEMA_SQL: SQLite (local mode, aiosqlite)
 - POSTGRES_SCHEMA_SQL: PostgreSQL (team mode, asyncpg)
 """
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 # Incremental ALTER TABLE migrations keyed by target version.
 MIGRATIONS: dict[int, list[str]] = {
@@ -137,6 +144,16 @@ MIGRATIONS: dict[int, list[str]] = {
                INSERT INTO facts_fts(rowid, content, scope, keywords)
                VALUES (new.rowid, new.content, new.scope, new.keywords);
            END""",
+    ],
+    11: [
+        # Invite key lifecycle: soft-revocation with grace period for active sessions.
+        # revoked_at: set when a key rotation is triggered; NULL = still active.
+        # grace_until: existing sessions may continue until this timestamp.
+        # rotation_reason: optional operator note stored at revocation time.
+        "ALTER TABLE invite_keys ADD COLUMN revoked_at TEXT",
+        "ALTER TABLE invite_keys ADD COLUMN grace_until TEXT",
+        "ALTER TABLE invite_keys ADD COLUMN rotation_reason TEXT",
+        "CREATE INDEX IF NOT EXISTS invite_keys_grace ON invite_keys(engram_id, grace_until)",
     ],
 }
 
@@ -279,13 +296,19 @@ CREATE TABLE IF NOT EXISTS workspaces (
 );
 
 -- Invite keys (db_url is encrypted into the key token, NOT stored here)
+-- revoked_at/grace_until support the key rotation lifecycle (schema v11).
 CREATE TABLE IF NOT EXISTS invite_keys (
     key_hash         TEXT PRIMARY KEY,
     engram_id        TEXT NOT NULL REFERENCES workspaces(engram_id),
     created_at       TEXT NOT NULL,
     expires_at       TEXT,
-    uses_remaining   INTEGER
+    uses_remaining   INTEGER,
+    revoked_at       TEXT,
+    grace_until      TEXT,
+    rotation_reason  TEXT
 );
+
+CREATE INDEX IF NOT EXISTS invite_keys_grace ON invite_keys(engram_id, grace_until);
 
 -- Schema version tracking
 CREATE TABLE IF NOT EXISTS schema_meta (
@@ -483,13 +506,19 @@ CREATE TABLE IF NOT EXISTS workspaces (
 );
 
 -- Invite keys (db_url encrypted into token, NOT stored here)
+-- revoked_at/grace_until support the key rotation lifecycle (schema v11).
 CREATE TABLE IF NOT EXISTS invite_keys (
     key_hash         TEXT PRIMARY KEY,
     engram_id        TEXT NOT NULL REFERENCES workspaces(engram_id),
     created_at       TIMESTAMPTZ NOT NULL,
     expires_at       TIMESTAMPTZ,
-    uses_remaining   INTEGER
+    uses_remaining   INTEGER,
+    revoked_at       TIMESTAMPTZ,
+    grace_until      TIMESTAMPTZ,
+    rotation_reason  TEXT
 );
+
+CREATE INDEX IF NOT EXISTS invite_keys_grace ON invite_keys(engram_id, grace_until);
 
 -- Webhooks (event subscriptions)
 CREATE TABLE IF NOT EXISTS webhooks (

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -95,18 +95,30 @@ _DISCONNECTED_NEXT_PROMPT = (
 async def _check_key_generation(ws: Any) -> dict[str, Any] | None:
     """Return a disconnected response if the local key_generation is behind the DB.
 
-    Returns None if the generation is current or the check cannot be performed.
+    When an invite key rotation has been performed with a grace period, agents
+    whose generation is behind are allowed to continue until the grace window
+    expires — only then do they receive the disconnected response.
+
+    Returns None if the generation is current (or within grace), or if the
+    check cannot be performed (local mode, storage not ready).
     """
     if _storage is None or not ws or not ws.db_url:
         return None
     db_gen = await _storage.get_key_generation(ws.engram_id)
-    if db_gen > ws.key_generation:
-        return {
-            "status": "disconnected",
-            "next_prompt": _DISCONNECTED_NEXT_PROMPT,
-            **tool_surface_metadata(),
-        }
-    return None
+    if db_gen <= ws.key_generation:
+        return None
+    # Generation is behind — check whether a grace window is still active.
+    grace_until = await _storage.get_active_grace_until(ws.engram_id)
+    if grace_until is not None:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if grace_until > now_iso:
+            # Within grace window — existing session may continue.
+            return None
+    return {
+        "status": "disconnected",
+        "next_prompt": _DISCONNECTED_NEXT_PROMPT,
+        **tool_surface_metadata(),
+    }
 
 
 # ── engram_status ─────────────────────────────────────────────────────
@@ -517,6 +529,8 @@ async def engram_rename(
 async def engram_reset_invite_key(
     invite_expires_days: int = 90,
     invite_uses: int = 10,
+    grace_minutes: int = 15,
+    reason: str = "",
 ) -> dict[str, Any]:
     """Reset the workspace invite key (workspace creator only).
 
@@ -528,21 +542,23 @@ async def engram_reset_invite_key(
     - As part of periodic security rotation (recommended: quarterly)
 
     **What NOT to do:**
-    - Don't call this without reason — all team members will be disconnected
+    - Don't call this without reason — all team members will eventually be disconnected
     - Don't call this if you're not the workspace creator — you'll get an error
     - Don't forget to share the new key with your team after resetting
 
     **Common mistake:** Forgetting to share the new invite key with team members after
-    resetting, leaving them unable to reconnect.
+    resetting, leaving them unable to reconnect after the grace period ends.
 
     Use this when you suspect a security breach or the current invite key
     has been compromised. This will:
-      1. Revoke all existing invite keys for your workspace.
+      1. Soft-revoke all existing invite keys (with a grace period for active sessions).
       2. Increment the workspace key generation counter.
       3. Generate a new invite key.
+      4. Write an audit log entry and fire a webhook event.
 
-    All existing members will be temporarily disconnected. They will see a
-    message telling them to obtain the new invite key and call engram_join.
+    Existing members in active sessions continue working until grace_minutes expires.
+    New join attempts with the old key are rejected immediately regardless of grace.
+    After the grace window, existing members see a reconnect message.
 
     This tool is only available to the workspace creator (the agent that
     originally called engram_init). Other agents will receive an error.
@@ -550,89 +566,51 @@ async def engram_reset_invite_key(
     Parameters:
     - invite_expires_days: Validity period for the new key (default 90 days).
     - invite_uses: Max number of times the new key can be used (default 10).
+    - grace_minutes: Grace window in minutes for active sessions (default 15, 0 = immediate).
+    - reason: Optional note explaining why the key was rotated (stored in audit log).
 
-    Returns: {status, invite_key, key_generation, next_prompt}
+    Returns: {status, invite_key, key_generation, grace_until, next_prompt}
 
-    Example: {"status": "ready", "invite_key": "ek_live_...", "key_generation": 2}
+    Example: {"status": "reset", "invite_key": "ek_live_...", "key_generation": 2}
     """
-    from engram.workspace import (
-        WorkspaceConfig,
-        generate_invite_key,
-        read_workspace,
-        write_workspace,
-    )
-
-    ws = read_workspace()
-    if ws is None or not ws.db_url:
-        return {
-            "status": "error",
-            "next_prompt": "No team workspace is configured. Only usable in team mode.",
-        }
-
-    if not ws.is_creator:
-        return {
-            "status": "error",
-            "next_prompt": (
-                "Only the workspace creator can reset the invite key. "
-                "If you set up this workspace, check that your workspace.json has is_creator=true."
-            ),
-        }
-
-    if _storage is None:
+    if _engine is None:
         return {
             "status": "error",
             "next_prompt": "Storage not initialized. Restart the Engram server and try again.",
         }
 
-    import time
+    try:
+        result = await _engine.rotate_invite_key(
+            expires_days=invite_expires_days,
+            uses=invite_uses,
+            grace_minutes=grace_minutes,
+            reason=reason or None,
+            actor=None,
+        )
+    except ValueError as exc:
+        return {"status": "error", "next_prompt": str(exc)}
+    except PermissionError as exc:
+        return {"status": "error", "next_prompt": str(exc)}
 
-    # Revoke all existing invite keys and bump the generation counter
-    await _storage.revoke_all_invite_keys(ws.engram_id)
-    new_gen = await _storage.bump_key_generation(ws.engram_id)
-
-    # Generate new invite key embedding the new generation
-    invite_key, key_hash = generate_invite_key(
-        db_url=ws.db_url,
-        engram_id=ws.engram_id,
-        expires_days=invite_expires_days,
-        uses_remaining=invite_uses,
-        schema=ws.schema,
-        key_generation=new_gen,
-    )
-
-    expires_ts = datetime.fromtimestamp(
-        time.time() + invite_expires_days * 86400, tz=timezone.utc
-    ).isoformat()
-    await _storage.insert_invite_key(
-        key_hash=key_hash,
-        engram_id=ws.engram_id,
-        expires_at=expires_ts,
-        uses_remaining=invite_uses,
-    )
-
-    # Update creator's local workspace.json with new generation
-    updated_config = WorkspaceConfig(
-        engram_id=ws.engram_id,
-        db_url=ws.db_url,
-        schema=ws.schema,
-        anonymous_mode=ws.anonymous_mode,
-        anon_agents=ws.anon_agents,
-        key_generation=new_gen,
-        is_creator=True,
-    )
-    write_workspace(updated_config)
-    logger.warning(
-        "Invite key reset by creator: workspace=%s, new_generation=%d", ws.engram_id, new_gen
+    invite_key = result["invite_key"]
+    new_gen = result["new_generation"]
+    grace_until = result.get("grace_until")
+    grace_note = (
+        f"\n\nActive sessions have a {grace_minutes}-minute grace period (until {grace_until}) "
+        f"before they are disconnected."
+        if grace_until
+        else "\n\nAll existing sessions have been disconnected immediately."
     )
 
     return {
         "status": "reset",
         "invite_key": invite_key,
         "key_generation": new_gen,
+        "grace_until": grace_until,
         "next_prompt": (
-            f"Security reset complete. All existing invite keys have been revoked.\n\n"
-            f"Key generation is now {new_gen}. All members have been temporarily "
-            f"disconnected — they will see a message asking them to reconnect.\n\n"
+            f"Security reset complete. All existing invite keys have been revoked.{grace_note}\n\n"
+            f"Key generation is now {new_gen}. Members will see a message asking them to reconnect "
+            f"once the grace period ends.\n\n"
             f"Share this new invite key with your team via a secure channel "
             f"(iMessage, WhatsApp, Slack DM, etc.):\n\n"
             f"  Invite Key: {invite_key}\n\n"

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -327,9 +327,7 @@ class BaseStorage(ABC):
         """
         return 0
 
-    async def get_key_rotation_history(
-        self, engram_id: str, limit: int = 20
-    ) -> list[dict]:
+    async def get_key_rotation_history(self, engram_id: str, limit: int = 20) -> list[dict]:
         """Return audit_log entries with operation='key_rotation' for the workspace.
 
         Ordered by timestamp descending. Default empty list for local mode.
@@ -1552,9 +1550,7 @@ class SQLiteStorage(BaseStorage):
         await self.db.commit()
         return cursor.rowcount
 
-    async def get_key_rotation_history(
-        self, engram_id: str, limit: int = 20
-    ) -> list[dict]:
+    async def get_key_rotation_history(self, engram_id: str, limit: int = 20) -> list[dict]:
         # In SQLite mode workspace_id in audit_log is self.workspace_id, not engram_id.
         cursor = await self.db.execute(
             """SELECT * FROM audit_log

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -296,8 +296,45 @@ class BaseStorage(ABC):
         """Return list of active invite keys. Default empty list."""
         return []
 
-    async def revoke_all_invite_keys(self, engram_id: str) -> None:
-        """Delete all invite keys for a workspace. Default no-op."""
+    async def revoke_all_invite_keys(
+        self,
+        engram_id: str,
+        *,
+        grace_minutes: int = 15,
+        reason: str | None = None,
+    ) -> None:
+        """Soft-revoke all active invite keys for a workspace.
+
+        If grace_minutes > 0, keys are marked revoked but kept in the table
+        until grace_until expires, allowing existing sessions to continue.
+        If grace_minutes == 0, keys are hard-deleted immediately.
+        Expired grace keys are always cleaned up as a side-effect.
+        Default no-op for local mode.
+        """
+
+    async def get_active_grace_until(self, engram_id: str) -> str | None:
+        """Return the latest grace_until among revoked-but-not-yet-expired keys.
+
+        Returns None if no grace window is currently active.
+        Default None for local mode.
+        """
+        return None
+
+    async def cleanup_expired_grace_keys(self, engram_id: str) -> int:
+        """Hard-delete revoked invite keys whose grace_until has passed.
+
+        Returns the number of rows deleted. Default 0 for local mode.
+        """
+        return 0
+
+    async def get_key_rotation_history(
+        self, engram_id: str, limit: int = 20
+    ) -> list[dict]:
+        """Return audit_log entries with operation='key_rotation' for the workspace.
+
+        Ordered by timestamp descending. Default empty list for local mode.
+        """
+        return []
 
     # ── Webhook methods ───────────────────────────────────────────────
 
@@ -1431,7 +1468,8 @@ class SQLiteStorage(BaseStorage):
             """SELECT * FROM invite_keys
                WHERE key_hash = ?
                  AND (expires_at IS NULL OR expires_at > ?)
-                 AND (uses_remaining IS NULL OR uses_remaining > 0)""",
+                 AND (uses_remaining IS NULL OR uses_remaining > 0)
+                 AND revoked_at IS NULL""",
             (key_hash, _now_iso()),
         )
         row = await cursor.fetchone()
@@ -1444,6 +1482,7 @@ class SQLiteStorage(BaseStorage):
                WHERE key_hash = ?
                  AND (expires_at IS NULL OR expires_at > ?)
                  AND (uses_remaining IS NULL OR uses_remaining > 0)
+                 AND revoked_at IS NULL
                RETURNING *""",
             (key_hash, _now_iso()),
         )
@@ -1466,9 +1505,66 @@ class SQLiteStorage(BaseStorage):
         await self.db.commit()
         return await self.get_key_generation(engram_id)
 
-    async def revoke_all_invite_keys(self, engram_id: str) -> None:
-        await self.db.execute("DELETE FROM invite_keys WHERE engram_id = ?", (engram_id,))
+    async def revoke_all_invite_keys(
+        self,
+        engram_id: str,
+        *,
+        grace_minutes: int = 15,
+        reason: str | None = None,
+    ) -> None:
+        # Purge any already-expired grace keys as a side-effect.
+        await self.db.execute(
+            "DELETE FROM invite_keys WHERE engram_id = ? AND revoked_at IS NOT NULL AND grace_until < datetime('now')",
+            (engram_id,),
+        )
+        if grace_minutes > 0:
+            await self.db.execute(
+                """UPDATE invite_keys
+                   SET revoked_at      = datetime('now'),
+                       grace_until     = datetime('now', ? || ' minutes'),
+                       rotation_reason = ?
+                   WHERE engram_id = ? AND revoked_at IS NULL""",
+                (f"+{grace_minutes}", reason, engram_id),
+            )
+        else:
+            await self.db.execute(
+                "DELETE FROM invite_keys WHERE engram_id = ? AND revoked_at IS NULL",
+                (engram_id,),
+            )
         await self.db.commit()
+
+    async def get_active_grace_until(self, engram_id: str) -> str | None:
+        cursor = await self.db.execute(
+            """SELECT MAX(grace_until) FROM invite_keys
+               WHERE engram_id = ?
+                 AND revoked_at IS NOT NULL
+                 AND grace_until > datetime('now')""",
+            (engram_id,),
+        )
+        row = await cursor.fetchone()
+        return row[0] if row and row[0] else None
+
+    async def cleanup_expired_grace_keys(self, engram_id: str) -> int:
+        cursor = await self.db.execute(
+            "DELETE FROM invite_keys WHERE engram_id = ? AND revoked_at IS NOT NULL AND grace_until < datetime('now')",
+            (engram_id,),
+        )
+        await self.db.commit()
+        return cursor.rowcount
+
+    async def get_key_rotation_history(
+        self, engram_id: str, limit: int = 20
+    ) -> list[dict]:
+        # In SQLite mode workspace_id in audit_log is self.workspace_id, not engram_id.
+        cursor = await self.db.execute(
+            """SELECT * FROM audit_log
+               WHERE operation = 'key_rotation' AND workspace_id = ?
+               ORDER BY timestamp DESC
+               LIMIT ?""",
+            (self.workspace_id, max(1, min(limit, 200))),
+        )
+        rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
 
     async def get_invite_keys(self) -> list[dict]:
         """Return list of active invite keys."""

--- a/tests/test_invite_key_lifecycle.py
+++ b/tests/test_invite_key_lifecycle.py
@@ -126,7 +126,9 @@ async def test_revoke_with_grace_grace_until_in_future(storage: Storage):
     # SQLite stores naive timestamps; compare as naive UTC.
     # SQLite stores naive UTC timestamps; compare naive-to-naive.
     grace_until = datetime.fromisoformat(grace_until_str)
-    assert grace_until > datetime.now(timezone.utc).replace(tzinfo=None), "grace_until must be in the future"
+    assert grace_until > datetime.now(timezone.utc).replace(tzinfo=None), (
+        "grace_until must be in the future"
+    )
 
 
 async def test_get_active_grace_until_returns_future_ts(storage: Storage):
@@ -140,7 +142,9 @@ async def test_get_active_grace_until_returns_future_ts(storage: Storage):
     # SQLite returns naive timestamps; strip tz info for comparison.
     grace_str = grace_until.replace("+00:00", "").rstrip("Z")
     grace_dt = datetime.fromisoformat(grace_str)
-    assert grace_dt > datetime.now(timezone.utc).replace(tzinfo=None), "Returned grace_until must be in the future"
+    assert grace_dt > datetime.now(timezone.utc).replace(tzinfo=None), (
+        "Returned grace_until must be in the future"
+    )
 
 
 async def test_get_active_grace_until_none_when_no_revoked_keys(storage: Storage):
@@ -210,9 +214,7 @@ async def test_immediate_revoke_hard_deletes_keys(storage: Storage):
 
     await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=0)
 
-    cursor = await storage.db.execute(
-        "SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,)
-    )
+    cursor = await storage.db.execute("SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,))
     row = await cursor.fetchone()
     assert row is None, "Immediate revocation must hard-delete the key row"
 
@@ -244,9 +246,7 @@ async def test_cleanup_expired_grace_keys_removes_expired_rows(storage: Storage)
     deleted = await storage.cleanup_expired_grace_keys(ENGRAM_ID_A)
 
     assert deleted == 1
-    cursor = await storage.db.execute(
-        "SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,)
-    )
+    cursor = await storage.db.execute("SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,))
     assert await cursor.fetchone() is None
 
 
@@ -297,8 +297,16 @@ async def test_get_key_rotation_history_returns_entries(storage: Storage):
 
     assert len(entries) == 2
     # Newest first
-    extra_0 = json.loads(entries[0]["extra"]) if isinstance(entries[0]["extra"], str) else entries[0]["extra"]
-    extra_1 = json.loads(entries[1]["extra"]) if isinstance(entries[1]["extra"], str) else entries[1]["extra"]
+    extra_0 = (
+        json.loads(entries[0]["extra"])
+        if isinstance(entries[0]["extra"], str)
+        else entries[0]["extra"]
+    )
+    extra_1 = (
+        json.loads(entries[1]["extra"])
+        if isinstance(entries[1]["extra"], str)
+        else entries[1]["extra"]
+    )
     assert extra_0["new_generation"] > extra_1["new_generation"]
 
 

--- a/tests/test_invite_key_lifecycle.py
+++ b/tests/test_invite_key_lifecycle.py
@@ -1,0 +1,496 @@
+"""Tests for the invite key rotation lifecycle.
+
+Covers:
+- Soft-revoke with grace period: revoked_at set, grace_until in the future.
+- Grace window allows existing sessions (get_active_grace_until returns future ts).
+- Grace window expiry: after grace_until passes, get_active_grace_until returns None.
+- New join attempts blocked on revoked keys (consume_invite_key returns None).
+- Immediate revocation (grace_minutes=0): hard DELETE, no grace.
+- Cleanup: cleanup_expired_grace_keys removes expired revoked rows, leaves active rows.
+- Audit log: rotation writes a key_rotation entry with correct extra JSON.
+- Rotation history: get_key_rotation_history returns entries newest-first.
+- Multiple rotations: second rotation cleans up expired grace rows and re-revokes.
+- Engine-level permission gate: rotate_invite_key raises PermissionError when not creator.
+- Isolation: rotating workspace A does not affect workspace B's keys.
+- validate_invite_key: revoked keys are rejected even within grace period.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from engram.engine import EngramEngine
+from engram.storage import Storage
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+ENGRAM_ID_A = "ENG-TEST-AAAA"
+ENGRAM_ID_B = "ENG-TEST-BBBB"
+
+
+def _ts(delta_seconds: float = 0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=delta_seconds)).isoformat()
+
+
+def _key_hash() -> str:
+    return uuid.uuid4().hex * 2  # 64-char hex, like SHA256
+
+
+async def _seed_workspace(storage: Storage, engram_id: str = ENGRAM_ID_A) -> None:
+    """Insert a workspace row so invite_keys FK constraint is satisfied."""
+    await storage.ensure_workspace(engram_id, anonymous_mode=False, anon_agents=False)
+
+
+async def _seed_key(
+    storage: Storage,
+    engram_id: str = ENGRAM_ID_A,
+    *,
+    expires_at: str | None = None,
+    uses_remaining: int | None = 5,
+) -> str:
+    """Insert an active invite key and return its hash."""
+    kh = _key_hash()
+    await storage.insert_invite_key(
+        key_hash=kh,
+        engram_id=engram_id,
+        expires_at=expires_at,
+        uses_remaining=uses_remaining,
+    )
+    return kh
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def storage(tmp_path: Path) -> Storage:
+    db_path = tmp_path / "test.db"
+    s = Storage(db_path=db_path)
+    await s.connect()
+    await _seed_workspace(s, ENGRAM_ID_A)
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def storage_two_workspaces(tmp_path: Path) -> Storage:
+    db_path = tmp_path / "test_two.db"
+    s = Storage(db_path=db_path)
+    await s.connect()
+    await _seed_workspace(s, ENGRAM_ID_A)
+    await _seed_workspace(s, ENGRAM_ID_B)
+    yield s
+    await s.close()
+
+
+# ── storage-level: soft revoke with grace ─────────────────────────────
+
+
+async def test_revoke_with_grace_sets_revoked_at(storage: Storage):
+    """After revoke_all_invite_keys(grace_minutes=15), revoked_at is populated."""
+    kh = await _seed_key(storage)
+
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=15)
+
+    cursor = await storage.db.execute(
+        "SELECT revoked_at, grace_until FROM invite_keys WHERE key_hash = ?", (kh,)
+    )
+    row = await cursor.fetchone()
+    assert row is not None, "Key row should still exist (soft revoke keeps it)"
+    assert row["revoked_at"] is not None, "revoked_at must be set after soft revoke"
+    assert row["grace_until"] is not None, "grace_until must be set when grace_minutes > 0"
+
+
+async def test_revoke_with_grace_grace_until_in_future(storage: Storage):
+    """grace_until should be approximately now + grace_minutes in the future."""
+    kh = await _seed_key(storage)
+    grace_minutes = 10
+
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=grace_minutes)
+
+    cursor = await storage.db.execute(
+        "SELECT grace_until FROM invite_keys WHERE key_hash = ?", (kh,)
+    )
+    row = await cursor.fetchone()
+    assert row is not None
+    grace_until_str = row["grace_until"]
+    # SQLite stores naive timestamps; compare as naive UTC.
+    # SQLite stores naive UTC timestamps; compare naive-to-naive.
+    grace_until = datetime.fromisoformat(grace_until_str)
+    assert grace_until > datetime.now(timezone.utc).replace(tzinfo=None), "grace_until must be in the future"
+
+
+async def test_get_active_grace_until_returns_future_ts(storage: Storage):
+    """get_active_grace_until returns a future ISO string when grace is active."""
+    await _seed_key(storage)
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=15)
+
+    grace_until = await storage.get_active_grace_until(ENGRAM_ID_A)
+
+    assert grace_until is not None, "Should return a grace_until string while in grace period"
+    # SQLite returns naive timestamps; strip tz info for comparison.
+    grace_str = grace_until.replace("+00:00", "").rstrip("Z")
+    grace_dt = datetime.fromisoformat(grace_str)
+    assert grace_dt > datetime.now(timezone.utc).replace(tzinfo=None), "Returned grace_until must be in the future"
+
+
+async def test_get_active_grace_until_none_when_no_revoked_keys(storage: Storage):
+    """get_active_grace_until returns None when there are no revoked keys at all."""
+    await _seed_key(storage)  # active key, not revoked
+
+    grace_until = await storage.get_active_grace_until(ENGRAM_ID_A)
+
+    assert grace_until is None
+
+
+async def test_get_active_grace_until_none_after_grace_expires(storage: Storage):
+    """get_active_grace_until returns None once grace_until is in the past."""
+    kh = await _seed_key(storage)
+    # Manually insert a revoked key with an already-expired grace_until
+    await storage.db.execute(
+        "UPDATE invite_keys SET revoked_at = datetime('now', '-1 minute'), "
+        "grace_until = datetime('now', '-30 seconds') WHERE key_hash = ?",
+        (kh,),
+    )
+    await storage.db.commit()
+
+    grace_until = await storage.get_active_grace_until(ENGRAM_ID_A)
+
+    assert grace_until is None, "Expired grace windows must not be returned"
+
+
+# ── storage-level: new join blocked on revoked key ────────────────────
+
+
+async def test_consume_invite_key_blocked_when_revoked(storage: Storage):
+    """consume_invite_key returns None for a revoked key even within grace period."""
+    kh = await _seed_key(storage)
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=15)
+
+    result = await storage.consume_invite_key(kh)
+
+    assert result is None, "Revoked key must not be consumable for new joins"
+
+
+async def test_consume_invite_key_works_for_active_key(storage: Storage):
+    """consume_invite_key succeeds for a non-revoked, valid key."""
+    kh = await _seed_key(storage, uses_remaining=3)
+
+    result = await storage.consume_invite_key(kh)
+
+    assert result is not None, "Active key should be consumable"
+    assert result["uses_remaining"] == 2
+
+
+async def test_validate_invite_key_blocked_when_revoked(storage: Storage):
+    """validate_invite_key returns None for revoked keys."""
+    kh = await _seed_key(storage)
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=15)
+
+    result = await storage.validate_invite_key(kh)
+
+    assert result is None, "Revoked key must not pass validation"
+
+
+# ── storage-level: immediate revocation (grace_minutes=0) ────────────
+
+
+async def test_immediate_revoke_hard_deletes_keys(storage: Storage):
+    """grace_minutes=0 performs a hard DELETE, leaving no rows."""
+    kh = await _seed_key(storage)
+
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=0)
+
+    cursor = await storage.db.execute(
+        "SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,)
+    )
+    row = await cursor.fetchone()
+    assert row is None, "Immediate revocation must hard-delete the key row"
+
+
+async def test_immediate_revoke_no_active_grace(storage: Storage):
+    """After grace_minutes=0 revocation, get_active_grace_until returns None."""
+    await _seed_key(storage)
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=0)
+
+    grace_until = await storage.get_active_grace_until(ENGRAM_ID_A)
+
+    assert grace_until is None
+
+
+# ── storage-level: cleanup expired grace keys ─────────────────────────
+
+
+async def test_cleanup_expired_grace_keys_removes_expired_rows(storage: Storage):
+    """cleanup_expired_grace_keys deletes rows whose grace_until has passed."""
+    kh = await _seed_key(storage)
+    # Manually set an already-expired grace
+    await storage.db.execute(
+        "UPDATE invite_keys SET revoked_at = datetime('now', '-2 minutes'), "
+        "grace_until = datetime('now', '-1 minute') WHERE key_hash = ?",
+        (kh,),
+    )
+    await storage.db.commit()
+
+    deleted = await storage.cleanup_expired_grace_keys(ENGRAM_ID_A)
+
+    assert deleted == 1
+    cursor = await storage.db.execute(
+        "SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,)
+    )
+    assert await cursor.fetchone() is None
+
+
+async def test_cleanup_does_not_remove_active_or_grace_rows(storage: Storage):
+    """cleanup_expired_grace_keys does not touch active keys or live grace windows."""
+    kh_active = await _seed_key(storage)
+    kh_grace = await _seed_key(storage)
+
+    # Soft-revoke one (future grace)
+    await storage.db.execute(
+        "UPDATE invite_keys SET revoked_at = datetime('now'), "
+        "grace_until = datetime('now', '+30 minutes') WHERE key_hash = ?",
+        (kh_grace,),
+    )
+    await storage.db.commit()
+
+    deleted = await storage.cleanup_expired_grace_keys(ENGRAM_ID_A)
+
+    assert deleted == 0
+    for kh in (kh_active, kh_grace):
+        cursor = await storage.db.execute(
+            "SELECT key_hash FROM invite_keys WHERE key_hash = ?", (kh,)
+        )
+        assert await cursor.fetchone() is not None
+
+
+# ── storage-level: rotation history via audit log ─────────────────────
+
+
+async def test_get_key_rotation_history_returns_entries(storage: Storage):
+    """get_key_rotation_history returns key_rotation audit entries newest-first."""
+    # Insert two synthetic rotation entries
+    for i in range(2):
+        await storage.insert_audit_entry(
+            {
+                "id": uuid.uuid4().hex,
+                "operation": "key_rotation",
+                "agent_id": None,
+                "fact_id": None,
+                "conflict_id": None,
+                "extra": json.dumps({"old_generation": i, "new_generation": i + 1}),
+                "timestamp": _ts(delta_seconds=i),
+                "workspace_id": ENGRAM_ID_A,
+            }
+        )
+
+    entries = await storage.get_key_rotation_history(ENGRAM_ID_A, limit=10)
+
+    assert len(entries) == 2
+    # Newest first
+    extra_0 = json.loads(entries[0]["extra"]) if isinstance(entries[0]["extra"], str) else entries[0]["extra"]
+    extra_1 = json.loads(entries[1]["extra"]) if isinstance(entries[1]["extra"], str) else entries[1]["extra"]
+    assert extra_0["new_generation"] > extra_1["new_generation"]
+
+
+async def test_get_key_rotation_history_empty_when_none(storage: Storage):
+    """get_key_rotation_history returns [] when no rotations have occurred."""
+    entries = await storage.get_key_rotation_history(ENGRAM_ID_A)
+    assert entries == []
+
+
+# ── storage-level: multiple rotations ────────────────────────────────
+
+
+async def test_second_rotation_cleans_up_expired_grace(storage: Storage):
+    """When rotating again, previously expired grace keys are hard-deleted."""
+    kh = await _seed_key(storage)
+    # First rotation — set grace to already-expired
+    await storage.db.execute(
+        "UPDATE invite_keys SET revoked_at = datetime('now', '-5 minutes'), "
+        "grace_until = datetime('now', '-1 minute') WHERE key_hash = ?",
+        (kh,),
+    )
+    await storage.db.commit()
+
+    # Insert a new active key and rotate again
+    kh2 = await _seed_key(storage)
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=15)
+
+    # Expired row (kh) should be gone; kh2 should be soft-revoked
+    cursor = await storage.db.execute(
+        "SELECT key_hash, revoked_at FROM invite_keys WHERE key_hash IN (?, ?)", (kh, kh2)
+    )
+    rows = {r["key_hash"]: r for r in await cursor.fetchall()}
+    assert kh not in rows, "Expired grace key must be cleaned up on subsequent rotation"
+    assert kh2 in rows
+    assert rows[kh2]["revoked_at"] is not None
+
+
+# ── storage-level: workspace isolation ───────────────────────────────
+
+
+async def test_revoke_does_not_affect_other_workspace(storage_two_workspaces: Storage):
+    """Revoking keys for workspace A must not touch workspace B's keys."""
+    storage = storage_two_workspaces
+    kh_a = await _seed_key(storage, ENGRAM_ID_A)
+    kh_b = await _seed_key(storage, ENGRAM_ID_B)
+
+    await storage.revoke_all_invite_keys(ENGRAM_ID_A, grace_minutes=15)
+
+    cursor_b = await storage.db.execute(
+        "SELECT revoked_at FROM invite_keys WHERE key_hash = ?", (kh_b,)
+    )
+    row_b = await cursor_b.fetchone()
+    assert row_b is not None
+    assert row_b["revoked_at"] is None, "Workspace B key must remain untouched"
+
+    cursor_a = await storage.db.execute(
+        "SELECT revoked_at FROM invite_keys WHERE key_hash = ?", (kh_a,)
+    )
+    row_a = await cursor_a.fetchone()
+    assert row_a["revoked_at"] is not None
+
+
+# ── engine-level: rotate_invite_key ──────────────────────────────────
+
+
+@pytest.fixture
+def mock_creator_ws():
+    """Return a mock WorkspaceConfig that identifies the caller as creator."""
+    ws = MagicMock()
+    ws.db_url = "sqlite:///test.db"
+    ws.engram_id = ENGRAM_ID_A
+    ws.schema = "engram"
+    ws.anonymous_mode = False
+    ws.anon_agents = False
+    ws.key_generation = 0
+    ws.is_creator = True
+    return ws
+
+
+@pytest.fixture
+def mock_non_creator_ws():
+    """Return a mock WorkspaceConfig that identifies the caller as NOT creator."""
+    ws = MagicMock()
+    ws.db_url = "sqlite:///test.db"
+    ws.engram_id = ENGRAM_ID_A
+    ws.is_creator = False
+    return ws
+
+
+async def test_engine_rotate_raises_permission_error_for_non_creator(storage: Storage):
+    """rotate_invite_key raises PermissionError when is_creator is False."""
+    engine = EngramEngine(storage)
+
+    with patch("engram.workspace.read_workspace") as mock_rw:
+        mock_rw.return_value = MagicMock(
+            db_url="sqlite:///test.db",
+            engram_id=ENGRAM_ID_A,
+            is_creator=False,
+        )
+        with pytest.raises(PermissionError, match="workspace creator"):
+            await engine.rotate_invite_key(grace_minutes=15)
+
+
+async def test_engine_rotate_raises_value_error_when_no_workspace(storage: Storage):
+    """rotate_invite_key raises ValueError when no workspace is configured."""
+    engine = EngramEngine(storage)
+
+    with patch("engram.workspace.read_workspace") as mock_rw:
+        mock_rw.return_value = None
+        with pytest.raises(ValueError, match="No team workspace"):
+            await engine.rotate_invite_key(grace_minutes=15)
+
+
+async def test_engine_rotate_writes_audit_log(storage: Storage, mock_creator_ws: MagicMock):
+    """rotate_invite_key writes a key_rotation audit log entry."""
+    engine = EngramEngine(storage)
+    await _seed_workspace(storage)  # ensure workspace row exists
+
+    with (
+        patch("engram.workspace.read_workspace", return_value=mock_creator_ws),
+        patch("engram.workspace.write_workspace"),
+        patch("engram.workspace.generate_invite_key", return_value=("ek_live_test", _key_hash())),
+        patch("engram.workspace.WorkspaceConfig"),
+    ):
+        await engine.rotate_invite_key(grace_minutes=10, reason="test rotation", actor="test-user")
+
+    entries = await storage.get_key_rotation_history(ENGRAM_ID_A, limit=5)
+    assert len(entries) >= 1
+    extra = entries[0].get("extra")
+    if isinstance(extra, str):
+        extra = json.loads(extra)
+    assert extra["reason"] == "test rotation"
+    assert extra["actor"] == "test-user"
+    assert extra["grace_minutes"] == 10
+    assert "new_generation" in extra
+
+
+async def test_engine_rotate_bumps_key_generation(storage: Storage, mock_creator_ws: MagicMock):
+    """rotate_invite_key increments the key_generation in the DB."""
+    engine = EngramEngine(storage)
+    await _seed_workspace(storage)
+
+    gen_before = await storage.get_key_generation(ENGRAM_ID_A)
+
+    with (
+        patch("engram.workspace.read_workspace", return_value=mock_creator_ws),
+        patch("engram.workspace.write_workspace"),
+        patch("engram.workspace.generate_invite_key", return_value=("ek_live_test", _key_hash())),
+        patch("engram.workspace.WorkspaceConfig"),
+    ):
+        result = await engine.rotate_invite_key(grace_minutes=5)
+
+    gen_after = await storage.get_key_generation(ENGRAM_ID_A)
+    assert gen_after == gen_before + 1
+    assert result["new_generation"] == gen_after
+    assert result["old_generation"] == gen_before
+
+
+async def test_engine_rotate_returns_grace_until_when_grace_set(
+    storage: Storage, mock_creator_ws: MagicMock
+):
+    """rotate_invite_key returns a grace_until string when grace_minutes > 0."""
+    engine = EngramEngine(storage)
+    await _seed_workspace(storage)
+
+    with (
+        patch("engram.workspace.read_workspace", return_value=mock_creator_ws),
+        patch("engram.workspace.write_workspace"),
+        patch("engram.workspace.generate_invite_key", return_value=("ek_live_test", _key_hash())),
+        patch("engram.workspace.WorkspaceConfig"),
+    ):
+        result = await engine.rotate_invite_key(grace_minutes=20)
+
+    assert result["grace_until"] is not None
+    grace_str = result["grace_until"].replace("+00:00", "").rstrip("Z")
+    grace_dt = datetime.fromisoformat(grace_str)
+    assert grace_dt > datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def test_engine_rotate_returns_none_grace_when_immediate(
+    storage: Storage, mock_creator_ws: MagicMock
+):
+    """rotate_invite_key returns None for grace_until when grace_minutes=0."""
+    engine = EngramEngine(storage)
+    await _seed_workspace(storage)
+
+    with (
+        patch("engram.workspace.read_workspace", return_value=mock_creator_ws),
+        patch("engram.workspace.write_workspace"),
+        patch("engram.workspace.generate_invite_key", return_value=("ek_live_test", _key_hash())),
+        patch("engram.workspace.WorkspaceConfig"),
+    ):
+        result = await engine.rotate_invite_key(grace_minutes=0)
+
+    assert result["grace_until"] is None


### PR DESCRIPTION
Resolves : #53 

- Bumped schema version to v11; added revoked_at, grace_until, rotation_reason columns to invite_keys in SQLite and PostgreSQL schemas
- Added MIGRATIONS[11] with ALTER TABLE statements and invite_keys_grace index
- Changed revoke_all_invite_keys to soft-revoke (with grace period) instead of hard DELETE; grace_minutes=0 preserves immediate-revocation behaviour
- Added get_active_grace_until, cleanup_expired_grace_keys, get_key_rotation_history to BaseStorage, SQLiteStorage, and PostgresStorage
- Added AND revoked_at IS NULL guard to consume_invite_key and validate_invite_key — revoked keys blocked from new joins even within grace window
- Added missing insert_audit_entry and get_audit_log implementations to PostgresStorage
- Added EngramEngine.rotate_invite_key: creator-gated, fires invite_key.rotated webhook, writes key_rotation audit log entry, returns grace_until
- Added EngramEngine.get_rotation_history wrapping storage query
- Refactored engram_reset_invite_key MCP tool to delegate to engine.rotate_invite_key; added grace_minutes and reason parameters
- Updated _check_key_generation to allow existing sessions to continue during active grace window
- Added engram invite rotate and engram invite history CLI subcommands
- Added POST /api/invite-key/rotate and GET /api/invite-key/history REST endpoints
- Added tests/test_invite_key_lifecycle.py with 22 async tests (all passing)
- Updated PRIVACY_ARCHITECTURE.md with Invite Key Lifecycle section including flow, grace period table, webhook payload, and operator checklist
- Updated MIGRATION_SCHEMA.md with v11 entry and upgrade SQL for both backends
- Updated CLAUDE.md with new schema version, module map entry, and tool description