### PR TITLE
feat: add pinned facts to always surface high-priority knowledge (issue #65)

### DIFF
--- a/src/engram/schema.py
+++ b/src/engram/schema.py
@@ -155,7 +155,9 @@ CREATE TABLE IF NOT EXISTS facts (
     workspace_id     TEXT NOT NULL DEFAULT 'local',
     corroborating_agents INTEGER NOT NULL DEFAULT 0,
     durability       TEXT NOT NULL DEFAULT 'durable',
-    query_hits       INTEGER NOT NULL DEFAULT 0
+    query_hits       INTEGER NOT NULL DEFAULT 0,
+    pinned           INTEGER NOT NULL DEFAULT 0,
+    pinned_at        TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_facts_validity     ON facts(scope, valid_until);

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -575,11 +575,29 @@ class SQLiteStorage(BaseStorage):
         params.append(offset)
 
         cursor = await self.db.execute(
-            f"SELECT * FROM facts WHERE {where} ORDER BY committed_at DESC LIMIT ? OFFSET ?",
+            f"SELECT * FROM facts WHERE {where} ORDER BY pinned DESC, committed_at DESC LIMIT ? OFFSET ?",
             params,
         )
         rows = await cursor.fetchall()
         return [dict(r) for r in rows]
+
+    async def pin_fact(self, fact_id: str) -> bool:
+        """Pin a fact to always appear at top of queries."""
+        from datetime import datetime, timezone
+
+        cursor = await self.db.execute(
+            "UPDATE facts SET pinned = 1, pinned_at = ? WHERE id = ? AND workspace_id = ?",
+            (datetime.now(timezone.utc).isoformat(), fact_id, self.workspace_id),
+        )
+        return cursor.rowcount > 0
+
+    async def unpin_fact(self, fact_id: str) -> bool:
+        """Unpin a fact."""
+        cursor = await self.db.execute(
+            "UPDATE facts SET pinned = 0, pinned_at = NULL WHERE id = ? AND workspace_id = ?",
+            (fact_id, self.workspace_id),
+        )
+        return cursor.rowcount > 0
 
     async def fts_search(self, query: str, limit: int = 20, offset: int = 0) -> list[int]:
         """FTS5 BM25 search. Returns rowids ordered by relevance."""


### PR DESCRIPTION
## Summary
- Add `pinned` column to facts schema (INTEGER DEFAULT 0, pinned_at TIMESTAMP)
- Add pinned to query ordering (pinned facts appear first in get_current_facts_in_scope)
- Add `pin_fact()` and `unpin_fact()` methods to SQLite storage

This feature allows users to pin important facts so they always appear at the top of query results, regardless of relevance score or recency.

Closes #65