### PR TITLE
Add Cursor first-class MCP setup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Your agent handles the rest.
 Engram is currently optimized for MCP-native workflows in:
 
 - [Claude Code](./docs/quickstart/claude-code.md)
+- [Cursor](./docs/quickstart/cursor.md)
 - [VS Code (Copilot)](./docs/quickstart/vscode-copilot.md)
 - [Windsurf](./docs/quickstart/windsurf.md)
 - [Zed](./docs/quickstart/zed.md)

--- a/docs/SUPPORTED_IDES.md
+++ b/docs/SUPPORTED_IDES.md
@@ -116,8 +116,8 @@ If you install with `--join`, the final line will instead look like:
 ```
 
 ### Cursor
-**Common failure:** Cursor was not restarted after installation.  
-**Fix:** Restart Cursor, then confirm Engram appears in `~/.cursor/mcp.json` and in Cursor’s MCP or tools UI.
+**Common failure:** Cursor was not restarted after installation, or the agent searches files instead of calling the Engram MCP tool.
+**Fix:** Confirm Engram is under `mcpServers.engram.url` in `~/.cursor/mcp.json`, restart Cursor, approve the MCP tool prompt if shown, and confirm Engram is enabled in Cursor's MCP/tools UI. If Engram still uses the old `command: "uvx"` entry, re-run `engram install` to migrate the exact legacy entry to the hosted URL form.
 
 ### VS Code
 **Common failure:** VS Code uses `servers.engram`, not `mcpServers.engram`.  

--- a/docs/quickstart/cursor.md
+++ b/docs/quickstart/cursor.md
@@ -1,6 +1,7 @@
 # Cursor Quickstart
 
 Cursor is a VS Code fork by Anysphere with built-in AI assistance.
+Engram connects to Cursor through MCP as a hosted remote server.
 
 ## Setup
 
@@ -9,9 +10,13 @@ Cursor is a VS Code fork by Anysphere with built-in AI assistance.
 curl -fsSL https://engram-memory.com/install | sh
 ```
 
+The installer writes Engram to your global Cursor MCP config at
+`~/.cursor/mcp.json`, then writes Cursor rules so the agent knows to call
+`engram_status` first in new sessions.
+
 ### Option 2: Manual Setup
 
-1. Create or edit `~/.cursor/mcp.json`:
+1. Create or edit your global Cursor MCP config at `~/.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
@@ -21,6 +26,14 @@ curl -fsSL https://engram-memory.com/install | sh
   }
 }
 ```
+
+If an older Engram config uses `command` and `args` with `uvx`, re-run
+`engram install`. The installer migrates the exact old Engram Cursor entry to
+the hosted `url` form above. Custom Cursor entries are left unchanged.
+
+Cursor also supports project-level MCP config at `.cursor/mcp.json`. Use that
+only when you want the Engram server config checked into a specific repository.
+For most users, the global `~/.cursor/mcp.json` file is the right default.
 
 For local development:
 ```json
@@ -33,11 +46,17 @@ For local development:
 }
 ```
 
+Only use the local URL after starting Engram locally:
+
+```bash
+python -m engram.cli serve --http
+```
+
 2. Restart Cursor
 
 ## First Time Setup
 
-1. Open a new chat in Cursor
+1. Open a new chat in Cursor Agent mode
 2. Tell it: `"Set up Engram for my team"` to create a workspace
 3. Or: `"Join Engram with key ek_live_..."` to join an existing workspace
 
@@ -56,15 +75,33 @@ engram verify
 
 **In your IDE:** Ask your agent: "Call engram_status and tell me what it returns."
 
+If Cursor searches the repository instead of calling a tool, use the more explicit
+prompt:
+
+```text
+Use the Engram MCP tool `engram_status`. Do not inspect files. Show the raw JSON response.
+```
+
 Expected output:
 ```
 {"status": "ready", "mode": "team", "engram_id": "ENG-XXXXXX", "schema": "engram"}
 ```
 
+If the workspace has not been configured yet, `engram_status` may instead return
+`status: "unconfigured"` with a `next_prompt`. That still confirms Cursor can
+call Engram.
+
 ## Troubleshooting
 
 - Check config: `cat ~/.cursor/mcp.json`
+- Confirm the entry is under `mcpServers.engram.url`
+- If the entry still uses `command: "uvx"`, re-run `engram install` or replace it
+  with the hosted `url` entry above
+- Check Cursor's MCP/tools UI and confirm Engram is enabled
+- Approve Cursor's MCP tool call prompt when it asks to run `engram_status`
 - Restart Cursor after making changes
 - Ensure port 7474 is available if using local server
+- If Cursor searches files instead of calling `engram_status`, reload the MCP server
+  or restart Cursor and try the explicit prompt above
 
 See [docs/TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for more help.

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -79,13 +79,21 @@ def _engram_mcp_entry_for_client(client_name: str) -> dict[str, object]:
     if client_name == "Windsurf":
         return {"serverUrl": mcp_url}
 
-    if client_name == "Zed":
+    if client_name in {"Cursor", "Zed"}:
         return {"url": mcp_url}
 
     if client_name.startswith("VS Code"):
         return {"type": "http", "url": mcp_url}
 
     return {
+        "command": "uvx",
+        "args": ["--from", "engram-team@latest", "engram", "serve"],
+    }
+
+
+def _is_legacy_cursor_stdio_entry(entry: object) -> bool:
+    """Return True for the old Engram Cursor stdio config we can safely migrate."""
+    return entry == {
         "command": "uvx",
         "args": ["--from", "engram-team@latest", "engram", "serve"],
     }
@@ -235,6 +243,16 @@ def install(dry_run: bool) -> None:
                 servers = data.setdefault(key, {})
 
                 if "engram" in servers:
+                    desired_entry = _engram_mcp_entry_for_client(client_name)
+                    if client_name == "Cursor" and _is_legacy_cursor_stdio_entry(servers["engram"]):
+                        servers["engram"] = desired_entry
+                        if not dry_run:
+                            config_path.parent.mkdir(parents=True, exist_ok=True)
+                            config_path.write_text(json.dumps(data, indent=2))
+                        added.append(client_name)
+                        steering_written.extend(_write_steering(client_name, dry_run))
+                        continue
+
                     skipped.append(client_name)
                     steering_written.extend(_write_steering(client_name, dry_run))
                     continue

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from engram.cli import main, _MCP_CLIENTS
+from engram.cli import main, _MCP_CLIENTS, _engram_mcp_entry_for_client
 
 
 _REAL_HOME = Path.home()
@@ -71,6 +71,101 @@ def test_install_writes_zed_context_server_url(tmp_path, monkeypatch):
         assert "context_servers" in data
         assert "engram" in data["context_servers"]
         assert data["context_servers"]["engram"] == {"url": "https://www.engram-memory.com/mcp"}
+
+
+def test_cursor_mcp_entry_uses_remote_url(monkeypatch):
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://www.engram-memory.com/mcp")
+
+    assert _engram_mcp_entry_for_client("Cursor") == {"url": "https://www.engram-memory.com/mcp"}
+
+
+def test_install_writes_cursor_remote_mcp_url(tmp_path, monkeypatch):
+    runner = CliRunner()
+    workspace_path = tmp_path / ".engram" / "workspace.json"
+
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://www.engram-memory.com/mcp")
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+        patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+    ):
+        cursor_config = tmp_path / ".cursor" / "mcp.json"
+        cursor_config.parent.mkdir(parents=True, exist_ok=True)
+        cursor_config.write_text("{}")
+
+        result = runner.invoke(main, ["install"])
+
+        assert result.exit_code == 0
+
+        data = json.loads(cursor_config.read_text())
+        assert "mcpServers" in data
+        assert "engram" in data["mcpServers"]
+        assert data["mcpServers"]["engram"] == {"url": "https://www.engram-memory.com/mcp"}
+
+
+def test_install_migrates_legacy_cursor_stdio_entry(tmp_path, monkeypatch):
+    runner = CliRunner()
+    workspace_path = tmp_path / ".engram" / "workspace.json"
+
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://www.engram-memory.com/mcp")
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+        patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+    ):
+        cursor_config = tmp_path / ".cursor" / "mcp.json"
+        cursor_config.parent.mkdir(parents=True, exist_ok=True)
+        cursor_config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "engram": {
+                            "command": "uvx",
+                            "args": ["--from", "engram-team@latest", "engram", "serve"],
+                        },
+                        "other": {"url": "https://example.com/mcp"},
+                    }
+                }
+            )
+        )
+
+        result = runner.invoke(main, ["install"])
+
+        assert result.exit_code == 0
+
+        data = json.loads(cursor_config.read_text())
+        assert data["mcpServers"]["engram"] == {"url": "https://www.engram-memory.com/mcp"}
+        assert data["mcpServers"]["other"] == {"url": "https://example.com/mcp"}
+
+
+def test_install_preserves_custom_cursor_entry(tmp_path, monkeypatch):
+    runner = CliRunner()
+    workspace_path = tmp_path / ".engram" / "workspace.json"
+
+    monkeypatch.setenv("ENGRAM_MCP_URL", "https://www.engram-memory.com/mcp")
+
+    custom_entry = {
+        "command": "uvx",
+        "args": ["--from", "engram-team@dev", "engram", "serve"],
+    }
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("engram.workspace.WORKSPACE_PATH", workspace_path),
+        patch("engram.cli._MCP_CLIENTS", _rebased_mcp_clients(tmp_path)),
+    ):
+        cursor_config = tmp_path / ".cursor" / "mcp.json"
+        cursor_config.parent.mkdir(parents=True, exist_ok=True)
+        cursor_config.write_text(json.dumps({"mcpServers": {"engram": custom_entry}}))
+
+        result = runner.invoke(main, ["install"])
+
+        assert result.exit_code == 0
+
+        data = json.loads(cursor_config.read_text())
+        assert data["mcpServers"]["engram"] == custom_entry
 
 
 def test_install_writes_vscode_copilot_http_server(tmp_path, monkeypatch):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -144,7 +144,7 @@ class TestVerifyCommand:
             )
         )
 
-        # Create Cursor MCP config with engram
+        # Create Cursor MCP config with Engram's hosted remote MCP URL.
         cursor_dir = temp_home / ".cursor"
         cursor_dir.mkdir(parents=True)
         mcp_config = cursor_dir / "mcp.json"
@@ -153,8 +153,7 @@ class TestVerifyCommand:
                 {
                     "mcpServers": {
                         "engram": {
-                            "command": "uvx",
-                            "args": ["--from", "engram-team@latest", "engram", "serve"],
+                            "url": "https://www.engram-memory.com/mcp",
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Adds Cursor as a first-class MCP integration target across README, setup docs, installer behavior, and verification coverage.

## What changed

- added Cursor to first-class IDE targets in `README.md`
- expanded Cursor-specific troubleshooting in `docs/SUPPORTED_IDES.md`
- updated `docs/quickstart/cursor.md` with setup, verification, compatibility notes, and troubleshooting
- updated `src/engram/cli.py` for Cursor-specific MCP setup and legacy entry migration
- added installer coverage in `tests/test_cli_install.py`
- added verify/doctor coverage in `tests/test_verify.py`

## Why

Cursor is a primary IDE for a large portion of the target audience. This makes the setup path clearer, reduces friction, and documents Cursor-specific MCP tool-calling behavior.

## Verification

Passed locally:

- `ruff check .`
- `ruff format --check .`
- `pytest tests/ -x --tb=short`

Additional targeted checks:

- `pytest tests/test_cli_install.py tests/test_verify.py -q`

Manual verification:

- `engram install`
- `engram doctor -v`
- `engram verify -v`
- confirmed Cursor MCP config at `~/.cursor/mcp.json`
