### PR TITLE
Add CLI importer for markdown and text docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Agents without MCP support connect via the REST API using the credentials in `.e
 engram install          # Configure your IDE and install the auto-commit hook
 engram verify           # Check that everything is connected
 engram search <query>   # Query workspace memory from the terminal
+engram import <path>    # Bulk-ingest Markdown/text docs
 engram tail             # Live stream of commits as they happen
 engram serve --http     # Run the MCP server locally (port 7474)
 ```

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -843,6 +843,120 @@ def search(topic: str, scope: str | None, limit: int, as_json: bool) -> None:
     click.echo(output)
 
 
+# ── engram import ────────────────────────────────────────────────────
+
+
+async def _import_once(
+    import_path: Path,
+    scope: str,
+    pattern: str,
+    dry_run: bool,
+) -> str:
+    """Import local Markdown/text files into the current workspace."""
+    from engram.engine import EngramEngine
+    from engram.importer import import_documents
+
+    storage = None
+    engine: EngramEngine
+
+    if dry_run:
+        engine = EngramEngine(storage=None)  # type: ignore[arg-type]
+    else:
+        import os
+
+        db_url = os.environ.get("ENGRAM_DB_URL", "")
+        workspace_id = "local"
+        schema = "engram"
+
+        try:
+            from engram.workspace import read_workspace
+
+            ws = read_workspace()
+            if ws and ws.db_url:
+                db_url = ws.db_url
+                workspace_id = ws.engram_id
+                schema = ws.schema
+        except Exception:
+            pass
+
+        if db_url:
+            from engram.postgres_storage import PostgresStorage
+
+            storage = PostgresStorage(db_url=db_url, workspace_id=workspace_id, schema=schema)
+        else:
+            from engram.storage import SQLiteStorage
+
+            storage = SQLiteStorage(db_path=str(DEFAULT_DB_PATH), workspace_id=workspace_id)
+
+        await storage.connect()
+        engine = EngramEngine(storage)
+
+    try:
+        summary = await import_documents(
+            engine,
+            import_path,
+            scope=scope,
+            pattern=pattern,
+            dry_run=dry_run,
+        )
+    finally:
+        if storage is not None:
+            await storage.close()
+
+    lines = [
+        "Engram import summary",
+        f"  Files scanned   : {summary.files_scanned}",
+        f"  Facts extracted : {summary.facts_extracted}",
+        f"  Committed       : {summary.committed}",
+        f"  Duplicates      : {summary.duplicates}",
+        f"  Skipped         : {summary.skipped}",
+    ]
+
+    if dry_run and summary.dry_run_facts:
+        lines.append("")
+        lines.append("Dry run facts:")
+        for idx, fact in enumerate(summary.dry_run_facts, start=1):
+            lines.append(f"  {idx}. [{fact['scope']}] {fact['content']}")
+            lines.append(f"     provenance={fact['provenance']}")
+
+    if summary.errors:
+        lines.append("")
+        lines.append("Errors:")
+        for issue in summary.errors[:10]:
+            lines.append(f"  - {issue.source}: {issue.message}")
+        if len(summary.errors) > 10:
+            lines.append(f"  ... {len(summary.errors) - 10} more")
+
+    return "\n".join(lines)
+
+
+@main.command("import")
+@click.argument("import_path", type=click.Path(exists=True, path_type=Path))
+@click.option("--dry-run", is_flag=True, help="Preview extracted facts without committing.")
+@click.option("--scope", default="imported", show_default=True, help="Scope for imported facts.")
+@click.option(
+    "--pattern",
+    default="*",
+    show_default=True,
+    help='Glob pattern for supported files, for example "*.md".',
+)
+def import_cmd(import_path: Path, dry_run: bool, scope: str, pattern: str) -> None:
+    """Bulk-ingest Markdown/text files into workspace memory."""
+    try:
+        output = asyncio.run(
+            _import_once(
+                import_path=import_path,
+                scope=scope,
+                pattern=pattern,
+                dry_run=dry_run,
+            )
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc))
+
+    click.echo(output)
+
+
 # ── engram tail ──────────────────────────────────────────────────────
 
 

--- a/src/engram/importer.py
+++ b/src/engram/importer.py
@@ -1,0 +1,273 @@
+"""Document importer for seeding Engram from existing Markdown/text files."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from engram.engine import EngramEngine
+
+logger = logging.getLogger("engram")
+
+SUPPORTED_EXTENSIONS = {".md", ".txt"}
+SKIPPED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "dist",
+    "build",
+}
+DEFAULT_CONFIDENCE = 0.7
+DEFAULT_FACT_TYPE = "observation"
+DEFAULT_AGENT_ID = "engram-import"
+DEFAULT_MAX_CHARS = 4000
+
+
+@dataclass
+class ImportIssue:
+    source: str
+    message: str
+
+
+@dataclass
+class ImportSummary:
+    files_scanned: int = 0
+    facts_extracted: int = 0
+    committed: int = 0
+    duplicates: int = 0
+    skipped: int = 0
+    errors: list[ImportIssue] = field(default_factory=list)
+    dry_run_facts: list[dict[str, Any]] = field(default_factory=list)
+
+
+def discover_import_files(path: Path, pattern: str = "*") -> list[Path]:
+    """Return supported Markdown/text files under *path* in stable order."""
+    path = path.expanduser()
+    if path.is_file():
+        return [path] if _is_supported_file(path, pattern) else []
+    if not path.exists():
+        raise FileNotFoundError(f"Import path does not exist: {path}")
+    if not path.is_dir():
+        raise ValueError(f"Import path is not a file or directory: {path}")
+
+    files: list[Path] = []
+    for candidate in path.rglob(pattern):
+        if any(part in SKIPPED_DIRS or part.startswith(".") for part in candidate.parts):
+            continue
+        if _is_supported_file(candidate, pattern):
+            files.append(candidate)
+    return sorted(files)
+
+
+def read_text_file(path: Path) -> str:
+    """Read a text file, replacing invalid bytes rather than aborting the import."""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def chunk_document(text: str, max_chars: int = DEFAULT_MAX_CHARS) -> list[str]:
+    """Split Markdown/text into chunks small enough for extraction."""
+    blocks = _split_markdown_blocks(text)
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    def flush() -> None:
+        nonlocal current, current_len
+        chunk = "\n\n".join(current).strip()
+        if chunk:
+            chunks.append(chunk)
+        current = []
+        current_len = 0
+
+    for block in blocks:
+        if len(block) > max_chars:
+            flush()
+            chunks.extend(_split_long_block(block, max_chars=max_chars))
+            continue
+
+        proposed_len = current_len + len(block) + (2 if current else 0)
+        if current and proposed_len > max_chars:
+            flush()
+
+        current.append(block)
+        current_len += len(block) + (2 if current_len else 0)
+
+    flush()
+    return chunks
+
+
+async def extract_atomic_statements(chunk: str, source: str) -> list[str]:
+    """Extract atomic statements from a document chunk.
+
+    Uses Anthropic Haiku when ANTHROPIC_API_KEY and the optional dependency are
+    available. Otherwise falls back to conservative paragraph/bullet extraction.
+    """
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        return _heuristic_extract_atomic_statements(chunk)
+
+    try:
+        import anthropic
+    except ImportError:
+        logger.debug("anthropic package not installed; using heuristic import extraction")
+        return _heuristic_extract_atomic_statements(chunk)
+
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+    prompt = (
+        "Extract atomic, durable engineering knowledge from this document chunk.\n"
+        "Return JSON only, as an array of short factual strings. Do not invent facts. "
+        "Omit vague, promotional, or duplicate statements.\n\n"
+        f"Source: {source}\n\n"
+        f"Document chunk:\n{chunk}"
+    )
+    try:
+        message = await client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1200,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = message.content[0].text.strip()
+        if raw.startswith("```"):
+            parts = raw.split("```")
+            raw = parts[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+            raw = raw.strip()
+        data = json.loads(raw)
+        if not isinstance(data, list):
+            return []
+        return _clean_statements(str(item) for item in data)
+    except Exception:
+        logger.exception("LLM import extraction failed for %s", source)
+        return _heuristic_extract_atomic_statements(chunk)
+
+
+def prepare_import_fact(statement: str, source: str, scope: str) -> dict[str, Any]:
+    """Build a fact payload for EngramEngine.commit_batch()."""
+    return {
+        "content": statement,
+        "scope": scope,
+        "confidence": DEFAULT_CONFIDENCE,
+        "fact_type": DEFAULT_FACT_TYPE,
+        "provenance": source,
+    }
+
+
+async def import_documents(
+    engine: EngramEngine,
+    path: Path,
+    *,
+    scope: str = "imported",
+    pattern: str = "*",
+    dry_run: bool = False,
+) -> ImportSummary:
+    """Import supported documents from *path* into Engram."""
+    summary = ImportSummary()
+    files = discover_import_files(path, pattern=pattern)
+    summary.files_scanned = len(files)
+
+    for file_path in files:
+        try:
+            text = read_text_file(file_path)
+            chunks = chunk_document(text)
+            file_facts: list[dict[str, Any]] = []
+
+            for chunk in chunks:
+                statements = await extract_atomic_statements(chunk, str(file_path))
+                for statement in statements:
+                    file_facts.append(prepare_import_fact(statement, str(file_path), scope))
+
+            summary.facts_extracted += len(file_facts)
+
+            if dry_run:
+                summary.dry_run_facts.extend(file_facts)
+                continue
+
+            results = await engine.commit_batch(
+                file_facts,
+                scope=scope,
+                agent_id=DEFAULT_AGENT_ID,
+            )
+            for result in results:
+                if result.get("success") and result.get("duplicate"):
+                    summary.duplicates += 1
+                elif result.get("success"):
+                    summary.committed += 1
+                else:
+                    summary.skipped += 1
+                    summary.errors.append(
+                        ImportIssue(str(file_path), str(result.get("error", "unknown error")))
+                    )
+        except Exception as exc:
+            summary.skipped += 1
+            summary.errors.append(ImportIssue(str(file_path), str(exc)))
+
+    return summary
+
+
+def _is_supported_file(path: Path, pattern: str) -> bool:
+    return path.is_file() and path.match(pattern) and path.suffix.lower() in SUPPORTED_EXTENSIONS
+
+
+def _split_markdown_blocks(text: str) -> list[str]:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    blocks = re.split(r"\n\s*\n", normalized)
+    return [block.strip() for block in blocks if block.strip()]
+
+
+def _split_long_block(block: str, max_chars: int) -> list[str]:
+    sentences = re.split(r"(?<=[.!?])\s+", block)
+    chunks: list[str] = []
+    current = ""
+    for sentence in sentences:
+        if not sentence:
+            continue
+        if current and len(current) + len(sentence) + 1 > max_chars:
+            chunks.append(current.strip())
+            current = sentence
+        else:
+            current = f"{current} {sentence}".strip()
+    if current:
+        chunks.append(current.strip())
+    return chunks
+
+
+def _heuristic_extract_atomic_statements(chunk: str) -> list[str]:
+    lines: list[str] = []
+    for raw_line in chunk.splitlines():
+        line = raw_line.strip()
+        line = re.sub(r"^#{1,6}\s+", "", line)
+        line = re.sub(r"^[-*+]\s+", "", line)
+        line = re.sub(r"^\d+\.\s+", "", line)
+        if line:
+            lines.append(line)
+
+    if not lines:
+        return []
+
+    candidates = re.split(r"(?<=[.!?])\s+", " ".join(lines))
+    return _clean_statements(candidates)
+
+
+def _clean_statements(statements: Any) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for statement in statements:
+        text = " ".join(str(statement).split())
+        if len(text) < 12:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(text)
+    return cleaned

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -1,0 +1,197 @@
+import asyncio
+import json
+from pathlib import Path
+
+import numpy as np
+from click.testing import CliRunner
+
+from engram.cli import main
+from engram.importer import chunk_document, discover_import_files, prepare_import_fact
+from engram.storage import SQLiteStorage
+
+
+async def _read_current_facts(db_path: Path) -> list[dict]:
+    storage = SQLiteStorage(db_path=db_path, workspace_id="local")
+    await storage.connect()
+    try:
+        return await storage.get_current_facts_in_scope(limit=50)
+    finally:
+        await storage.close()
+
+
+def _patch_import_environment(monkeypatch, db_path: Path, statements: list[str] | Exception):
+    monkeypatch.setattr("engram.cli.DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr("engram.workspace.read_workspace", lambda: None)
+    monkeypatch.setenv("ENGRAM_DB_URL", "")
+    monkeypatch.setattr(
+        "engram.embeddings.encode",
+        lambda text: np.array([1.0, 0.0], dtype=np.float32),
+    )
+    monkeypatch.setattr("engram.embeddings.get_model_version", lambda: "test-version")
+
+    async def fake_extract(chunk: str, source: str) -> list[str]:
+        if isinstance(statements, Exception):
+            raise statements
+        return statements
+
+    monkeypatch.setattr("engram.importer.extract_atomic_statements", fake_extract)
+
+
+def test_discover_import_files_supports_markdown_and_text(tmp_path):
+    (tmp_path / "notes.md").write_text("# Notes")
+    (tmp_path / "runbook.txt").write_text("Runbook")
+    (tmp_path / "data.json").write_text("{}")
+    hidden = tmp_path / ".git"
+    hidden.mkdir()
+    (hidden / "ignored.md").write_text("Ignore me")
+
+    files = discover_import_files(tmp_path)
+
+    assert files == [tmp_path / "notes.md", tmp_path / "runbook.txt"]
+
+
+def test_chunk_document_splits_large_markdown():
+    text = "# Heading\n\n" + ("Sentence one. " * 500) + "\n\n## Next\n\nSentence two."
+
+    chunks = chunk_document(text, max_chars=200)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 220 for chunk in chunks)
+
+
+def test_prepare_import_fact_uses_import_defaults():
+    fact = prepare_import_fact(
+        "The auth service uses JWT session tokens.",
+        "docs/auth.md",
+        "docs",
+    )
+
+    assert fact == {
+        "content": "The auth service uses JWT session tokens.",
+        "scope": "docs",
+        "confidence": 0.7,
+        "fact_type": "observation",
+        "provenance": "docs/auth.md",
+    }
+
+
+def test_import_markdown_commits_extracted_facts(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    source = docs / "auth.md"
+    source.write_text("# Auth\n\nThe auth service uses JWT session tokens.")
+    _patch_import_environment(
+        monkeypatch,
+        db_path,
+        ["The auth service uses JWT session tokens."],
+    )
+
+    result = CliRunner().invoke(main, ["import", str(docs), "--scope", "docs"])
+
+    assert result.exit_code == 0, result.output
+    assert "Files scanned   : 1" in result.output
+    assert "Facts extracted : 1" in result.output
+    assert "Committed       : 1" in result.output
+
+    facts = asyncio.run(_read_current_facts(db_path))
+    assert len(facts) == 1
+    assert facts[0]["content"] == "The auth service uses JWT session tokens."
+    assert facts[0]["scope"] == "docs"
+    assert facts[0]["confidence"] == 0.7
+    assert facts[0]["fact_type"] == "observation"
+    assert facts[0]["provenance"] == str(source)
+
+
+def test_import_text_file_commits_fact(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    source = tmp_path / "runbook.txt"
+    source.write_text("Payments retries failed webhooks with exponential backoff.")
+    _patch_import_environment(
+        monkeypatch,
+        db_path,
+        ["Payments retries failed webhooks with exponential backoff."],
+    )
+
+    result = CliRunner().invoke(main, ["import", str(source), "--scope", "payments"])
+
+    assert result.exit_code == 0, result.output
+    facts = asyncio.run(_read_current_facts(db_path))
+    assert len(facts) == 1
+    assert facts[0]["scope"] == "payments"
+    assert facts[0]["provenance"] == str(source)
+
+
+def test_import_dry_run_does_not_write(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    source = tmp_path / "notes.md"
+    source.write_text("The dashboard runs at /dashboard.")
+    _patch_import_environment(monkeypatch, db_path, ["The dashboard runs at /dashboard."])
+
+    result = CliRunner().invoke(main, ["import", str(source), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Facts extracted : 1" in result.output
+    assert "Committed       : 0" in result.output
+    assert "Dry run facts:" in result.output
+    assert not db_path.exists()
+
+
+def test_import_pattern_skips_unsupported_files(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    (tmp_path / "data.json").write_text(json.dumps({"fact": "ignore me"}))
+    _patch_import_environment(monkeypatch, db_path, ["This should not be imported."])
+
+    result = CliRunner().invoke(main, ["import", str(tmp_path), "--pattern", "*.json"])
+
+    assert result.exit_code == 0, result.output
+    assert "Files scanned   : 0" in result.output
+    assert "Facts extracted : 0" in result.output
+    facts = asyncio.run(_read_current_facts(db_path))
+    assert facts == []
+
+
+def test_import_reports_extractor_failure(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    source = tmp_path / "notes.md"
+    source.write_text("The queue has a dead-letter policy.")
+    _patch_import_environment(monkeypatch, db_path, RuntimeError("extractor failed"))
+
+    result = CliRunner().invoke(main, ["import", str(source)])
+
+    assert result.exit_code == 0, result.output
+    assert "Skipped         : 1" in result.output
+    assert "extractor failed" in result.output
+
+
+def test_import_reports_duplicate_commits(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "one.md").write_text("Redis runs on port 6379.")
+    (docs / "two.md").write_text("Redis runs on port 6379.")
+    _patch_import_environment(monkeypatch, db_path, ["Redis runs on port 6379."])
+
+    result = CliRunner().invoke(main, ["import", str(docs), "--scope", "infra"])
+
+    assert result.exit_code == 0, result.output
+    assert "Facts extracted : 2" in result.output
+    assert "Committed       : 1" in result.output
+    assert "Duplicates      : 1" in result.output
+
+
+def test_import_reports_rejected_secret(monkeypatch, tmp_path):
+    db_path = tmp_path / "engram.db"
+    source = tmp_path / "secrets.md"
+    source.write_text("The API key is documented here.")
+    _patch_import_environment(
+        monkeypatch,
+        db_path,
+        ["API key is sk-abc123def456ghi789jkl012mno345pqr"],
+    )
+
+    result = CliRunner().invoke(main, ["import", str(source)])
+
+    assert result.exit_code == 0, result.output
+    assert "Skipped         : 1" in result.output
+    assert "appears to contain a secret" in result.output


### PR DESCRIPTION
## Summary

Adds a v1 `engram import <path>` CLI command for bulk-ingesting existing Markdown/text documentation into Engram.

The importer:
- discovers local `.md` and `.txt` files
- skips hidden/build directories
- chunks documents before extraction
- extracts atomic statements through a mockable extractor boundary
- commits imported facts through `EngramEngine.commit_batch()`
- uses `confidence=0.7`, `fact_type="observation"`, and source-file provenance
- supports `--dry-run`, `--scope`, and `--pattern`

This focuses on exported Markdown/text directories as the first step for #37. Direct Confluence, Notion, and Jira API integrations are intentionally out of scope for this PR.

## Testing

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_cli_import.py -q` — 10 passed
- `.venv/bin/pytest tests/ -x --tb=short` — 404 passed

Manual smoke test:
- Created temporary `/tmp/engram-import-demo` with `.md`, `.txt`, and `.png` files.
- Ran `ANTHROPIC_API_KEY= .venv/bin/python -m engram.cli import /tmp/engram-import-demo --dry-run --scope docs`.
- Verified `.md`/`.txt` were scanned, `.png` was ignored, and dry-run committed nothing.
- Ran `.venv/bin/python -m engram.cli import /tmp/engram-import-demo --scope docs`.
- Verified two facts were committed locally through the normal Engram commit pipeline.
- Removed the temporary folder afterward.

