### PR TITLE
Add effective confidence scoring for retrieval

### DIFF
--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -40,6 +40,46 @@ def _load_entities(raw: Any) -> list[dict[str, Any]]:
     return json.loads(raw) if raw else []
 
 
+def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _fact_age_days(fact: dict[str, Any], now: datetime | None = None) -> int:
+    try:
+        committed = datetime.fromisoformat(fact["committed_at"])
+        if committed.tzinfo is None:
+            committed = committed.replace(tzinfo=timezone.utc)
+        reference = now or datetime.now(timezone.utc)
+        return max(0, (reference - committed).days)
+    except (KeyError, ValueError, TypeError):
+        return 0
+
+
+def _effective_confidence(
+    fact: dict[str, Any],
+    *,
+    has_open_conflict: bool = False,
+    now: datetime | None = None,
+) -> float:
+    """Compute query-time confidence without mutating the stored value."""
+    base = _clamp(float(fact.get("confidence") or 0.0))
+    query_hits = max(0, int(fact.get("query_hits") or 0))
+    corroborating_agents = max(0, int(fact.get("corroborating_agents") or 0))
+    days_old = _fact_age_days(fact, now=now)
+
+    unreinforced = query_hits == 0 and corroborating_agents == 0
+    decay_rate = 0.006 if unreinforced else 0.003
+    confidence = base * math.exp(-decay_rate * days_old)
+
+    confidence += min(0.15, 0.06 * math.log1p(corroborating_agents))
+    confidence += min(0.10, 0.025 * math.log1p(query_hits))
+
+    if has_open_conflict:
+        confidence -= 0.20
+
+    return _clamp(confidence)
+
+
 class EngramEngine:
     """Core engine coordinating commit, query, detection, and resolution."""
 
@@ -622,12 +662,19 @@ class EngramEngine:
                 # This fact IS a correction — boost it slightly
                 supersession_penalty = 1.05
 
+            has_open_conflict = fid in open_conflict_ids
+            effective_confidence = _effective_confidence(
+                fact,
+                has_open_conflict=has_open_conflict,
+            )
+
             # Combined score — weights tuned for relevance at scale.
             # Recency is the strongest signal after relevance because at
             # 100k+ facts, old context is the primary source of noise.
             score = (
                 relevance
                 + 0.25 * recency
+                + 0.2 * effective_confidence
                 + 0.15 * trust
                 + 0.15 * fact_type_weight
                 + 0.1 * provenance_weight
@@ -651,7 +698,7 @@ class EngramEngine:
 
             # Penalize facts with unresolved conflicts — disputed facts
             # should not confidently inform agent decisions
-            if fid in open_conflict_ids:
+            if has_open_conflict:
                 score *= 0.5
 
             scored.append((score, fact))
@@ -666,19 +713,28 @@ class EngramEngine:
             is_ephemeral = fact.get("durability") == "ephemeral"
             if is_ephemeral:
                 ephemeral_ids.append(fact["id"])
+            has_open_conflict = fact["id"] in open_conflict_ids
             results.append(
                 {
                     "fact_id": fact["id"],
                     "content": fact["content"],
                     "scope": fact["scope"],
                     "confidence": fact["confidence"],
+                    "effective_confidence": round(
+                        _effective_confidence(
+                            fact,
+                            has_open_conflict=has_open_conflict,
+                        ),
+                        4,
+                    ),
                     "fact_type": fact["fact_type"],
                     "agent_id": fact["agent_id"],
                     "committed_at": fact["committed_at"],
-                    "has_open_conflict": fact["id"] in open_conflict_ids,
+                    "has_open_conflict": has_open_conflict,
                     "verified": fact.get("provenance") is not None,
                     "provenance": fact.get("provenance"),
                     "corroborating_agents": fact.get("corroborating_agents", 0),
+                    "query_hits": fact.get("query_hits", 0),
                     "relevance_score": round(score, 4),
                     "durability": fact.get("durability", "durable"),
                     "adjacent": False,
@@ -702,9 +758,13 @@ class EngramEngine:
             results.sort(key=lambda r: r["relevance_score"], reverse=True)
             results = results[:limit]
 
-        # Track query hits on ephemeral facts and auto-promote if threshold met
+        # Track query hits for confidence reinforcement. Ephemeral facts also
+        # use query hits for auto-promotion.
+        returned_ids = [str(r["fact_id"]) for r in results]
+        if returned_ids:
+            await self.storage.increment_query_hits(returned_ids)
+        ephemeral_ids = [str(r["fact_id"]) for r in results if r.get("durability") == "ephemeral"]
         if ephemeral_ids:
-            await self.storage.increment_query_hits(ephemeral_ids)
             # Auto-promote ephemeral facts that have now been queried enough
             promotable = await self.storage.get_promotable_ephemeral_facts(min_hits=2)
             for pf in promotable:
@@ -794,7 +854,12 @@ class EngramEngine:
             if sim < similarity_threshold:
                 continue
 
-            score = sim * score_penalty
+            has_open_conflict = fact["id"] in open_conflict_ids
+            effective_confidence = _effective_confidence(
+                fact,
+                has_open_conflict=has_open_conflict,
+            )
+            score = (sim + 0.2 * effective_confidence) * score_penalty
 
             results.append(
                 {
@@ -802,13 +867,15 @@ class EngramEngine:
                     "content": fact["content"],
                     "scope": fact["scope"],
                     "confidence": fact["confidence"],
+                    "effective_confidence": round(effective_confidence, 4),
                     "fact_type": fact["fact_type"],
                     "agent_id": fact["agent_id"],
                     "committed_at": fact["committed_at"],
-                    "has_open_conflict": fact["id"] in open_conflict_ids,
+                    "has_open_conflict": has_open_conflict,
                     "verified": fact.get("provenance") is not None,
                     "provenance": fact.get("provenance"),
                     "corroborating_agents": fact.get("corroborating_agents", 0),
+                    "query_hits": fact.get("query_hits", 0),
                     "relevance_score": round(score, 4),
                     "durability": fact.get("durability", "durable"),
                     "adjacent": True,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,11 +3,93 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pytest
 
-from engram.engine import EngramEngine
+from engram.engine import EngramEngine, _effective_confidence
+
+
+def _confidence_fact(**overrides):
+    fact = {
+        "confidence": 0.8,
+        "committed_at": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+        "query_hits": 0,
+        "corroborating_agents": 0,
+    }
+    fact.update(overrides)
+    return fact
+
+
+async def _update_fact_reinforcement(
+    engine: EngramEngine,
+    fact_id: str,
+    *,
+    committed_at: datetime | None = None,
+    query_hits: int | None = None,
+    corroborating_agents: int | None = None,
+) -> None:
+    assignments = []
+    params = []
+    if committed_at is not None:
+        committed_iso = committed_at.isoformat()
+        assignments.extend(["committed_at = ?", "valid_from = ?"])
+        params.extend([committed_iso, committed_iso])
+    if query_hits is not None:
+        assignments.append("query_hits = ?")
+        params.append(query_hits)
+    if corroborating_agents is not None:
+        assignments.append("corroborating_agents = ?")
+        params.append(corroborating_agents)
+
+    params.append(fact_id)
+    await engine.storage.db.execute(
+        f"UPDATE facts SET {', '.join(assignments)} WHERE id = ?",
+        params,
+    )
+    await engine.storage.db.commit()
+
+
+def test_effective_confidence_decays_unreinforced_facts():
+    now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+    fresh = _confidence_fact(committed_at=now.isoformat())
+    old = _confidence_fact(committed_at=(now - timedelta(days=120)).isoformat())
+
+    assert _effective_confidence(old, now=now) < _effective_confidence(fresh, now=now)
+
+
+def test_effective_confidence_boosts_corroboration_and_query_hits():
+    now = datetime(2026, 1, 31, tzinfo=timezone.utc)
+    old = _confidence_fact(committed_at=(now - timedelta(days=60)).isoformat())
+    reinforced = _confidence_fact(
+        committed_at=(now - timedelta(days=60)).isoformat(),
+        query_hits=8,
+        corroborating_agents=3,
+    )
+
+    assert _effective_confidence(reinforced, now=now) > _effective_confidence(old, now=now)
+
+
+def test_effective_confidence_penalizes_open_conflicts():
+    fact = _confidence_fact()
+
+    assert _effective_confidence(fact, has_open_conflict=True) < _effective_confidence(
+        fact,
+        has_open_conflict=False,
+    )
+
+
+def test_effective_confidence_is_clamped():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    fact = _confidence_fact(
+        confidence=0.99,
+        committed_at=now.isoformat(),
+        query_hits=1000,
+        corroborating_agents=1000,
+    )
+
+    assert _effective_confidence(fact, now=now) == 1.0
 
 
 @pytest.mark.asyncio
@@ -121,6 +203,75 @@ async def test_query_returns_results(engine: EngramEngine):
     results = await engine.query(topic="auth rate limiting", scope="auth")
     assert len(results) >= 1
     assert results[0]["content"] == "The auth service rate-limits to 1000 req/s per IP"
+
+
+@pytest.mark.asyncio
+async def test_query_returns_effective_confidence_and_preserves_raw_confidence(
+    engine: EngramEngine,
+    monkeypatch,
+):
+    from engram import embeddings
+
+    monkeypatch.setattr(embeddings, "encode", lambda text: np.ones(384, dtype=np.float32))
+    monkeypatch.setattr(embeddings, "get_model_version", lambda: "test-version")
+
+    result = await engine.commit(
+        content="The auth service signs session tokens with rotating keys",
+        scope="auth",
+        confidence=0.7,
+        agent_id="agent-1",
+    )
+
+    results = await engine.query(topic="session tokens", scope="auth")
+
+    hit = next(r for r in results if r["fact_id"] == result["fact_id"])
+    assert hit["confidence"] == 0.7
+    assert "effective_confidence" in hit
+    assert 0.0 <= hit["effective_confidence"] <= 1.0
+
+    stored = await engine.storage.get_fact_by_id(result["fact_id"])
+    assert stored["confidence"] == 0.7
+    assert stored["query_hits"] == 1
+
+
+@pytest.mark.asyncio
+async def test_query_ranking_uses_effective_confidence(engine: EngramEngine, monkeypatch):
+    from engram import embeddings
+
+    monkeypatch.setattr(embeddings, "encode", lambda text: np.ones(384, dtype=np.float32))
+    monkeypatch.setattr(embeddings, "get_model_version", lambda: "test-version")
+
+    old = await engine.commit(
+        content="Cache entries expire according to the legacy runbook",
+        scope="cache",
+        confidence=0.95,
+        agent_id="agent-1",
+    )
+    reinforced = await engine.commit(
+        content="Cache entries expire according to the current service runbook",
+        scope="cache",
+        confidence=0.7,
+        agent_id="agent-2",
+    )
+
+    await _update_fact_reinforcement(
+        engine,
+        old["fact_id"],
+        committed_at=datetime.now(timezone.utc) - timedelta(days=180),
+        query_hits=0,
+        corroborating_agents=0,
+    )
+    await _update_fact_reinforcement(
+        engine,
+        reinforced["fact_id"],
+        query_hits=10,
+        corroborating_agents=3,
+    )
+
+    results = await engine.query(topic="cache expiration policy", scope="cache", limit=2)
+
+    assert results[0]["fact_id"] == reinforced["fact_id"]
+    assert results[0]["effective_confidence"] > results[1]["effective_confidence"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a v1 effective confidence scoring model for fact retrieval.

The scoring model combines:
- stored base confidence
- age-based decay
- faster decay for facts with no query or corroboration reinforcement
- bounded boost from corroborating agents
- bounded boost from query hits
- clamping between `0.0` and `1.0`

Retrieval ranking now uses `effective_confidence`, so stale unused facts rank lower while corroborated or frequently queried facts can surface higher. Query results also expose `effective_confidence` while preserving the stored raw `confidence`.

This keeps v1 focused on existing signals and avoids a schema change. Distinct querying-agent tracking is intentionally left as a follow-up.

## Testing

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_engine.py -q`
- `.venv/bin/pytest tests/ -x --tb=short` — 437 passed

## Notes

This PR does not add unique querying-agent tracking. It uses existing `corroborating_agents` and `query_hits` signals as the first scoring model for #18.
