### PR TITLE
Add memory diff CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ engram install          # Configure your IDE and install the auto-commit hook
 engram verify           # Check that everything is connected
 engram search <query>   # Query workspace memory from the terminal
 engram import <path>    # Bulk-ingest Markdown/text docs
+engram diff --from <time> --to <time>  # Show memory changes over a time window
 engram tail             # Live stream of commits as they happen
 engram serve --http     # Run the MCP server locally (port 7474)
 ```

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1363,6 +1363,168 @@ def tail(scope: str | None, limit: int, interval: float, base_url: str) -> None:
         raise click.ClickException(str(exc))
 
 
+# ── engram diff ──────────────────────────────────────────────────────
+
+
+def _format_diff_fact(fact: dict[str, object], timestamp_key: str) -> str:
+    timestamp = fact.get(timestamp_key) or "-"
+    scope = fact.get("scope") or "-"
+    content = fact.get("content") or ""
+    fact_id = str(fact.get("id") or "")[:12]
+    return f"- [{timestamp}] [{scope}] {content} ({fact_id})"
+
+
+def _format_diff_conflict(conflict: dict[str, object]) -> str:
+    timestamp = conflict.get("resolved_at") or "-"
+    status = conflict.get("status") or "-"
+    conflict_id = str(conflict.get("id") or conflict.get("conflict_id") or "")[:12]
+    fact_a = conflict.get("fact_a_content") or conflict.get("fact_a_id") or ""
+    fact_b = conflict.get("fact_b_content") or conflict.get("fact_b_id") or ""
+    return f"- [{timestamp}] [{status}] {fact_a} <> {fact_b} ({conflict_id})"
+
+
+def _format_memory_diff(diff: dict[str, object]) -> str:
+    summary = diff.get("summary") or {}
+    if not isinstance(summary, dict):
+        summary = {}
+
+    lines = [
+        "Memory diff",
+        f"  From              : {diff.get('from')}",
+        f"  To                : {diff.get('to')}",
+    ]
+    if diff.get("scope"):
+        lines.append(f"  Scope             : {diff.get('scope')}")
+    lines.extend(
+        [
+            f"  Added facts       : {summary.get('added', 0)}",
+            f"  Superseded facts  : {summary.get('superseded', 0)}",
+            f"  Resolved conflicts: {summary.get('resolved_conflicts', 0)}",
+        ]
+    )
+
+    added = diff.get("added") or []
+    superseded = diff.get("superseded") or []
+    resolved = diff.get("resolved_conflicts") or []
+
+    if added:
+        lines.append("\nAdded facts:")
+        lines.extend(_format_diff_fact(fact, "committed_at") for fact in added)  # type: ignore[arg-type]
+    if superseded:
+        lines.append("\nSuperseded/retired facts:")
+        lines.extend(_format_diff_fact(fact, "valid_until") for fact in superseded)  # type: ignore[arg-type]
+    if resolved:
+        lines.append("\nResolved conflicts:")
+        lines.extend(_format_diff_conflict(conflict) for conflict in resolved)  # type: ignore[arg-type]
+
+    return "\n".join(lines)
+
+
+async def _diff_once(
+    from_time: str,
+    to_time: str,
+    scope: str | None,
+    limit: int,
+    as_json: bool,
+) -> str:
+    """Run one terminal memory diff against the current workspace."""
+    import os
+
+    from engram.engine import EngramEngine
+
+    logger = logging.getLogger("engram")
+    db_url = os.environ.get("ENGRAM_DB_URL", "")
+    workspace_id = "local"
+    schema = "engram"
+
+    try:
+        from engram.workspace import read_workspace
+
+        ws = read_workspace()
+        if ws and ws.db_url:
+            db_url = ws.db_url
+            workspace_id = ws.engram_id
+            schema = ws.schema
+    except Exception:
+        pass
+
+    if db_url:
+        from engram.postgres_storage import PostgresStorage
+
+        storage = PostgresStorage(db_url=db_url, workspace_id=workspace_id, schema=schema)
+        logger.info("Diff mode: PostgreSQL (workspace: %s, schema: %s)", workspace_id, schema)
+    else:
+        from engram.storage import SQLiteStorage
+
+        storage = SQLiteStorage(db_path=str(DEFAULT_DB_PATH), workspace_id=workspace_id)
+        logger.info("Diff mode: SQLite (%s, workspace: %s)", DEFAULT_DB_PATH, workspace_id)
+
+    await storage.connect()
+    engine = EngramEngine(storage)
+
+    try:
+        diff = await engine.diff_memory(from_time, to_time, scope=scope, limit=limit)
+    finally:
+        await storage.close()
+
+    if as_json:
+        return json.dumps(diff, indent=2)
+    return _format_memory_diff(diff)
+
+
+@main.command("diff")
+@click.option(
+    "--from",
+    "from_time",
+    required=True,
+    help="Start of the diff window as an ISO-8601 timestamp.",
+)
+@click.option(
+    "--to",
+    "to_time",
+    required=True,
+    help="End of the diff window as an ISO-8601 timestamp.",
+)
+@click.option("--scope", default=None, help="Optional scope prefix to filter changes.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--limit",
+    default=1000,
+    type=click.IntRange(1, 1000),
+    show_default=True,
+    help="Maximum rows per diff bucket.",
+)
+def diff_cmd(
+    from_time: str,
+    to_time: str,
+    scope: str | None,
+    output_format: str,
+    limit: int,
+) -> None:
+    """Show memory changes over a time window."""
+    try:
+        output = asyncio.run(
+            _diff_once(
+                from_time=from_time,
+                to_time=to_time,
+                scope=scope,
+                limit=limit,
+                as_json=output_format == "json",
+            )
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc))
+
+    click.echo(output)
+
+
 # ── engram status ───────────────────────────────────────────────────────
 
 

--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -113,6 +113,17 @@ def _has_negation_mismatch(left: str, right: str) -> bool:
     )
 
 
+def _parse_window_timestamp(value: str, label: str) -> datetime:
+    """Parse a CLI/API timestamp and normalize naive values to UTC."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO-8601 timestamp.") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 class EngramEngine:
     """Core engine coordinating commit, query, detection, and resolution."""
 
@@ -1685,6 +1696,53 @@ class EngramEngine:
             scope_filter=scope,
             anonymous_mode=anonymous_mode,
         )
+
+    # ── engram_diff ───────────────────────────────────────────────────
+
+    async def diff_memory(
+        self,
+        from_time: str,
+        to_time: str,
+        scope: str | None = None,
+        limit: int = 1000,
+    ) -> dict[str, Any]:
+        """Return memory changes over a time window.
+
+        The diff is read-only and groups changes into added facts, retired or
+        superseded facts, and resolved/dismissed conflicts.
+        """
+        start = _parse_window_timestamp(from_time, "--from")
+        end = _parse_window_timestamp(to_time, "--to")
+        if start >= end:
+            raise ValueError("--from must be earlier than --to.")
+
+        limit = max(1, min(limit, 1000))
+        start_iso = start.isoformat()
+        end_iso = end.isoformat()
+
+        added = await self.storage.get_facts_added_between(
+            start_iso, end_iso, scope=scope, limit=limit
+        )
+        superseded = await self.storage.get_facts_retired_between(
+            start_iso, end_iso, scope=scope, limit=limit
+        )
+        resolved_conflicts = await self.storage.get_conflicts_resolved_between(
+            start_iso, end_iso, scope=scope, limit=limit
+        )
+
+        return {
+            "from": start_iso,
+            "to": end_iso,
+            "scope": scope,
+            "summary": {
+                "added": len(added),
+                "superseded": len(superseded),
+                "resolved_conflicts": len(resolved_conflicts),
+            },
+            "added": added,
+            "superseded": superseded,
+            "resolved_conflicts": resolved_conflicts,
+        }
 
     # ── lineage ───────────────────────────────────────────────────────
 

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -921,6 +921,91 @@ class PostgresStorage(BaseStorage):
             )
         return [_row_to_dict(r) for r in rows]
 
+    async def get_facts_added_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]:
+        conditions = ["workspace_id = $1", "committed_at >= $2", "committed_at <= $3"]
+        params: list[Any] = [self.workspace_id, start, end]
+        idx = 4
+        if scope:
+            conditions.append(f"(scope = ${idx} OR scope LIKE ${idx} || '/%')")
+            params.append(scope)
+            idx += 1
+        params.append(limit)
+        where = " AND ".join(conditions)
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                f"""SELECT id, lineage_id, content, scope, confidence, fact_type,
+                          agent_id, engineer, committed_at, valid_from, valid_until,
+                          supersedes_fact_id, durability
+                   FROM facts
+                   WHERE {where}
+                   ORDER BY committed_at ASC
+                   LIMIT ${idx}""",
+                *params,
+            )
+        return [_row_to_dict(r) for r in rows]
+
+    async def get_facts_retired_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]:
+        conditions = ["workspace_id = $1", "valid_until >= $2", "valid_until <= $3"]
+        params: list[Any] = [self.workspace_id, start, end]
+        idx = 4
+        if scope:
+            conditions.append(f"(scope = ${idx} OR scope LIKE ${idx} || '/%')")
+            params.append(scope)
+            idx += 1
+        params.append(limit)
+        where = " AND ".join(conditions)
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                f"""SELECT id, lineage_id, content, scope, confidence, fact_type,
+                          agent_id, engineer, committed_at, valid_from, valid_until,
+                          supersedes_fact_id, durability
+                   FROM facts
+                   WHERE {where}
+                   ORDER BY valid_until ASC
+                   LIMIT ${idx}""",
+                *params,
+            )
+        return [_row_to_dict(r) for r in rows]
+
+    async def get_conflicts_resolved_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]:
+        conditions = [
+            "c.workspace_id = $1",
+            "c.resolved_at >= $2",
+            "c.resolved_at <= $3",
+            "c.status != 'open'",
+        ]
+        params: list[Any] = [self.workspace_id, start, end]
+        idx = 4
+        if scope:
+            conditions.append(
+                f"(fa.scope = ${idx} OR fa.scope LIKE ${idx} || '/%' "
+                f"OR fb.scope = ${idx} OR fb.scope LIKE ${idx} || '/%')"
+            )
+            params.append(scope)
+            idx += 1
+        params.append(limit)
+        where = " AND ".join(conditions)
+        async with self.acquire() as conn:
+            rows = await conn.fetch(
+                f"""SELECT c.*,
+                          fa.content AS fact_a_content, fa.scope AS fact_a_scope,
+                          fb.content AS fact_b_content, fb.scope AS fact_b_scope
+                   FROM conflicts c
+                   JOIN facts fa ON c.fact_a_id = fa.id
+                   JOIN facts fb ON c.fact_b_id = fb.id
+                   WHERE {where}
+                   ORDER BY c.resolved_at ASC
+                   LIMIT ${idx}""",
+                *params,
+            )
+        return [_row_to_dict(r) for r in rows]
+
     async def get_fact_timeline(self, scope: str | None = None, limit: int = 100) -> list[dict]:
         conditions = ["workspace_id = $1"]
         params: list[Any] = [self.workspace_id]

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -230,6 +230,21 @@ class BaseStorage(ABC):
     ) -> list[dict]: ...
 
     @abstractmethod
+    async def get_facts_added_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]: ...
+
+    @abstractmethod
+    async def get_facts_retired_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]: ...
+
+    @abstractmethod
+    async def get_conflicts_resolved_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]: ...
+
+    @abstractmethod
     async def ingest_remote_fact(self, fact: dict[str, Any]) -> bool: ...
 
     @abstractmethod
@@ -1293,6 +1308,87 @@ class SQLiteStorage(BaseStorage):
         where = " AND ".join(conditions)
         cursor = await self.db.execute(
             f"SELECT * FROM facts WHERE {where} ORDER BY committed_at ASC LIMIT ?",
+            params,
+        )
+        rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
+
+    async def get_facts_added_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]:
+        """Return facts committed within a time window."""
+        conditions = ["workspace_id = ?", "committed_at >= ?", "committed_at <= ?"]
+        params: list[Any] = [self.workspace_id, start, end]
+        if scope:
+            conditions.append("(scope = ? OR scope LIKE ? || '/%')")
+            params.extend([scope, scope])
+        params.append(limit)
+        where = " AND ".join(conditions)
+        cursor = await self.db.execute(
+            f"""SELECT id, lineage_id, content, scope, confidence, fact_type,
+                       agent_id, engineer, committed_at, valid_from, valid_until,
+                       supersedes_fact_id, durability
+                FROM facts
+                WHERE {where}
+                ORDER BY committed_at ASC
+                LIMIT ?""",
+            params,
+        )
+        rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
+
+    async def get_facts_retired_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]:
+        """Return facts whose validity window closed within a time window."""
+        conditions = ["workspace_id = ?", "valid_until >= ?", "valid_until <= ?"]
+        params: list[Any] = [self.workspace_id, start, end]
+        if scope:
+            conditions.append("(scope = ? OR scope LIKE ? || '/%')")
+            params.extend([scope, scope])
+        params.append(limit)
+        where = " AND ".join(conditions)
+        cursor = await self.db.execute(
+            f"""SELECT id, lineage_id, content, scope, confidence, fact_type,
+                       agent_id, engineer, committed_at, valid_from, valid_until,
+                       supersedes_fact_id, durability
+                FROM facts
+                WHERE {where}
+                ORDER BY valid_until ASC
+                LIMIT ?""",
+            params,
+        )
+        rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
+
+    async def get_conflicts_resolved_between(
+        self, start: str, end: str, scope: str | None = None, limit: int = 1000
+    ) -> list[dict]:
+        """Return conflicts resolved or dismissed within a time window."""
+        conditions = [
+            "c.workspace_id = ?",
+            "c.resolved_at >= ?",
+            "c.resolved_at <= ?",
+            "c.status != 'open'",
+        ]
+        params: list[Any] = [self.workspace_id, start, end]
+        if scope:
+            conditions.append(
+                "(fa.scope = ? OR fa.scope LIKE ? || '/%' OR fb.scope = ? OR fb.scope LIKE ? || '/%')"
+            )
+            params.extend([scope, scope, scope, scope])
+        params.append(limit)
+        where = " AND ".join(conditions)
+        cursor = await self.db.execute(
+            f"""SELECT c.*,
+                       fa.content AS fact_a_content, fa.scope AS fact_a_scope,
+                       fb.content AS fact_b_content, fb.scope AS fact_b_scope
+                FROM conflicts c
+                JOIN facts fa ON c.fact_a_id = fa.id
+                JOIN facts fb ON c.fact_b_id = fb.id
+                WHERE {where}
+                ORDER BY c.resolved_at ASC
+                LIMIT ?""",
             params,
         )
         rows = await cursor.fetchall()

--- a/tests/test_memory_diff.py
+++ b/tests/test_memory_diff.py
@@ -1,0 +1,180 @@
+"""Tests for memory diff over workspace time windows."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from click.testing import CliRunner
+import pytest
+
+from engram.cli import main
+from engram.engine import EngramEngine
+
+
+def _ts(hours: int = 0) -> str:
+    base = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    return (base + timedelta(hours=hours)).isoformat()
+
+
+def _fact(
+    *,
+    content: str,
+    scope: str = "api",
+    committed_at: str | None = None,
+    valid_until: str | None = None,
+) -> dict:
+    now = committed_at or _ts()
+    return {
+        "id": uuid.uuid4().hex,
+        "lineage_id": uuid.uuid4().hex,
+        "content": content,
+        "content_hash": uuid.uuid4().hex,
+        "scope": scope,
+        "confidence": 0.8,
+        "fact_type": "observation",
+        "agent_id": "agent-1",
+        "engineer": "Tunde",
+        "provenance": None,
+        "keywords": "[]",
+        "entities": "[]",
+        "artifact_hash": None,
+        "embedding": None,
+        "embedding_model": "test",
+        "embedding_ver": "test",
+        "committed_at": now,
+        "valid_from": now,
+        "valid_until": valid_until,
+        "ttl_days": None,
+        "memory_op": "add",
+        "supersedes_fact_id": None,
+        "durability": "durable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_diff_memory_reports_added_retired_and_resolved_conflicts(engine: EngramEngine):
+    added = _fact(content="The API timeout is 30 seconds", committed_at=_ts(1))
+    outside = _fact(content="Outside the window", committed_at=_ts(-5))
+    retired = _fact(
+        content="Old API timeout was 10 seconds",
+        committed_at=_ts(-4),
+        valid_until=_ts(2),
+    )
+    conflict_a = _fact(content="Auth timeout is 30 seconds", scope="auth", committed_at=_ts(-3))
+    conflict_b = _fact(content="Auth timeout is 60 seconds", scope="auth", committed_at=_ts(-2))
+
+    for fact in (added, outside, retired, conflict_a, conflict_b):
+        await engine.storage.insert_fact(fact)
+
+    conflict_id = uuid.uuid4().hex
+    await engine.storage.insert_conflict(
+        {
+            "id": conflict_id,
+            "fact_a_id": conflict_a["id"],
+            "fact_b_id": conflict_b["id"],
+            "detected_at": _ts(-1),
+            "detection_tier": "tier2_numeric",
+            "entailment_score": 0.1,
+            "contradiction_score": 0.9,
+            "explanation": "timeout differs",
+            "severity": "high",
+            "status": "open",
+        }
+    )
+    assert await engine.storage.resolve_conflict(
+        conflict_id,
+        resolution_type="dismissed",
+        resolution="false positive",
+        resolved_by="agent-reviewer",
+    )
+    await engine.storage.db.execute(
+        "UPDATE conflicts SET resolved_at = ? WHERE id = ?",
+        (_ts(2), conflict_id),
+    )
+    await engine.storage.db.commit()
+
+    result = await engine.diff_memory(_ts(0), _ts(3))
+
+    assert result["summary"] == {
+        "added": 1,
+        "superseded": 1,
+        "resolved_conflicts": 1,
+    }
+    assert [fact["id"] for fact in result["added"]] == [added["id"]]
+    assert [fact["id"] for fact in result["superseded"]] == [retired["id"]]
+    assert [conflict["id"] for conflict in result["resolved_conflicts"]] == [conflict_id]
+
+
+@pytest.mark.asyncio
+async def test_diff_memory_applies_scope_filter(engine: EngramEngine):
+    auth_fact = _fact(content="Auth uses JWT", scope="auth/jwt", committed_at=_ts(1))
+    payments_fact = _fact(content="Payments use Stripe", scope="payments", committed_at=_ts(1))
+    await engine.storage.insert_fact(auth_fact)
+    await engine.storage.insert_fact(payments_fact)
+
+    result = await engine.diff_memory(_ts(0), _ts(2), scope="auth")
+
+    assert result["summary"]["added"] == 1
+    assert result["added"][0]["id"] == auth_fact["id"]
+
+
+@pytest.mark.asyncio
+async def test_diff_memory_rejects_invalid_window(engine: EngramEngine):
+    with pytest.raises(ValueError, match="earlier"):
+        await engine.diff_memory(_ts(2), _ts(1))
+
+
+@pytest.mark.asyncio
+async def test_diff_memory_rejects_invalid_timestamp(engine: EngramEngine):
+    with pytest.raises(ValueError, match="ISO-8601"):
+        await engine.diff_memory("yesterday", _ts(1))
+
+
+def test_diff_command_outputs_json(monkeypatch):
+    async def fake_diff_once(from_time, to_time, scope, limit, as_json):
+        assert from_time == "2026-04-15T00:00:00Z"
+        assert to_time == "2026-04-16T00:00:00Z"
+        assert scope == "auth"
+        assert limit == 1000
+        assert as_json is True
+        return json.dumps({"summary": {"added": 1}})
+
+    monkeypatch.setattr("engram.cli._diff_once", fake_diff_once)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "diff",
+            "--from",
+            "2026-04-15T00:00:00Z",
+            "--to",
+            "2026-04-16T00:00:00Z",
+            "--scope",
+            "auth",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"summary": {"added": 1}}
+
+
+def test_diff_command_outputs_text(monkeypatch):
+    async def fake_diff_once(from_time, to_time, scope, limit, as_json):
+        assert as_json is False
+        return "Memory diff\n  Added facts       : 0"
+
+    monkeypatch.setattr("engram.cli._diff_once", fake_diff_once)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["diff", "--from", "2026-04-15T00:00:00Z", "--to", "2026-04-16T00:00:00Z"],
+    )
+
+    assert result.exit_code == 0
+    assert "Memory diff" in result.output


### PR DESCRIPTION
## Summary

Adds a focused v1 `engram diff` CLI command to show how workspace memory changed between two timestamps.

This is a read-only, CLI-first implementation that reports:
- facts added
- facts superseded/retired
- resolved conflicts

It keeps v1 scoped to existing timestamps and avoids schema changes or dashboard work.

## What changed

- added read-only time-window storage helpers in:
  - `src/engram/storage.py`
  - `src/engram/postgres_storage.py`
- added `diff_memory(from_time, to_time, scope=None, limit=1000)` in `src/engram/engine.py`
  - validates ISO timestamps
  - rejects `from >= to`
  - returns structured buckets for:
    - `added`
    - `superseded`
    - `resolved_conflicts`
- added `engram diff` in `src/engram/cli.py`
  - `--from`
  - `--to`
  - `--scope`
  - `--format text|json`
- updated `README.md` to include the new CLI command
- added focused coverage in `tests/test_memory_diff.py`

## Why

This addresses the need to answer:

- what was added during a window
- what was superseded during a window
- what conflicts were resolved during a window

That makes incident review and audit workflows more practical without expanding scope into UI or schema work.

## Verification

Passed locally:

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_memory_diff.py -q` — 6 passed
- `.venv/bin/pytest tests/ -x --tb=short` — 483 passed, 18 warnings

Coverage added for:

- added facts inside the window
- outside-window facts excluded
- superseded/retired facts inside the window
- resolved conflicts inside the window
- scope filtering
- invalid timestamp handling
- invalid time window handling
- CLI JSON output
- CLI text output

Closes #19
