### PR TITLE
feat: add conflict_type classification, conflict.detected webhook, and per-tier stats

### DIFF
--- a/src/engram/dashboard.py
+++ b/src/engram/dashboard.py
@@ -98,12 +98,16 @@ def build_dashboard_routes(storage: Storage, engine: Any = None) -> list[Route]:
         return HTMLResponse(_render_lineage_timeline(lineage))
 
     async def knowledge_base(request: Request) -> HTMLResponse:
-        scope = request.query_params.get("scope")
-        fact_type = request.query_params.get("fact_type")
-        as_of = request.query_params.get("as_of")
+        scope = request.query_params.get("scope") or ""
+        fact_type = request.query_params.get("fact_type") or ""
+        as_of = request.query_params.get("as_of") or ""
         search_query = request.query_params.get("q", "").strip()
         offset = int(request.query_params.get("offset", 0))
         limit = int(request.query_params.get("limit", 100))
+
+        scope_filter = scope or None
+        fact_type_filter = fact_type or None
+        as_of_filter = as_of or None
 
         # Use FTS search if query provided
         if search_query:
@@ -116,17 +120,17 @@ def build_dashboard_routes(storage: Storage, engine: Any = None) -> list[Route]:
             except Exception:
                 # FTS fallback - use regular query
                 facts = await storage.get_current_facts_in_scope(
-                    scope=scope, fact_type=fact_type, as_of=as_of, limit=limit, offset=offset
+                    scope=scope_filter, fact_type=fact_type_filter, as_of=as_of_filter, limit=limit, offset=offset
                 )
         else:
             facts = await storage.get_current_facts_in_scope(
-                scope=scope, fact_type=fact_type, as_of=as_of, limit=limit, offset=offset
+                scope=scope_filter, fact_type=fact_type_filter, as_of=as_of_filter, limit=limit, offset=offset
             )
 
         if not facts and offset > 0:
             offset = 0
             facts = await storage.get_current_facts_in_scope(
-                scope=scope, fact_type=fact_type, as_of=as_of, limit=limit, offset=0
+                scope=scope_filter, fact_type=fact_type_filter, as_of=as_of_filter, limit=limit, offset=0
             )
 
         scopes = await storage.get_distinct_scopes()
@@ -136,6 +140,9 @@ def build_dashboard_routes(storage: Storage, engine: Any = None) -> list[Route]:
                 facts,
                 conflict_ids,
                 search_query=search_query,
+                scope=scope,
+                fact_type=fact_type,
+                as_of=as_of,
                 offset=offset,
                 limit=limit,
                 scopes=scopes,
@@ -146,13 +153,15 @@ def build_dashboard_routes(storage: Storage, engine: Any = None) -> list[Route]:
         scope = request.query_params.get("scope") or None
         status = request.query_params.get("status", "open")
         if engine is None:
-            return HTMLResponse(_render_conflicts_page([], stats={"open": 0, "resolved": 0}))
+            return HTMLResponse(
+                _render_conflicts_page([], stats={"open": 0, "resolved": 0}, scope=scope, status=status)
+            )
         conflicts = await engine.get_conflicts(scope=scope, status=status)
         stats = {
             "open": await storage.count_conflicts("open"),
             "resolved": await storage.count_conflicts("resolved"),
         }
-        return HTMLResponse(_render_conflicts_page(conflicts, stats=stats))
+        return HTMLResponse(_render_conflicts_page(conflicts, stats=stats, scope=scope, status=status))
 
     async def approve_suggestion(request: Request) -> Response:
         """HTMX: approve the LLM-suggested resolution for a conflict."""
@@ -214,10 +223,10 @@ def build_dashboard_routes(storage: Storage, engine: Any = None) -> list[Route]:
         return HTMLResponse(_render_conflict_card(updated or conflict))
 
     async def timeline(request: Request) -> HTMLResponse:
-        scope = request.query_params.get("scope")
-        facts = await storage.get_fact_timeline(scope=scope, limit=100)
+        scope = request.query_params.get("scope") or ""
+        facts = await storage.get_fact_timeline(scope=scope or None, limit=100)
         scopes = await storage.get_distinct_scopes()
-        return HTMLResponse(_render_timeline(facts, scopes=scopes))
+        return HTMLResponse(_render_timeline(facts, scopes=scopes, scope=scope))
 
     async def agents_view(request: Request) -> HTMLResponse:
         search_query = request.query_params.get("q", "").strip()
@@ -525,6 +534,9 @@ _DASH_STYLE = """
               border-radius: 4px; border: 1px solid #c6e9c6; }
   .escalation-note { font-size: 0.7rem; color: #d97706; margin-left: auto; }
   .badge-auto { background: #e0f2fe; color: #0369a1; }
+  .badge-genuine { background: #fee2e2; color: #dc2626; }
+  .badge-evolution { background: #e0f2fe; color: #0369a1; }
+  .badge-ambiguous { background: #fef3c7; color: #d97706; }
 
   .conflict-facts { display: grid; grid-template-columns: 1fr auto 1fr;
                     gap: 0.75rem; align-items: start; margin-bottom: 0.75rem; }
@@ -825,10 +837,15 @@ def _render_facts_table(
     facts: list[dict],
     conflict_ids: set[str],
     search_query: str = "",
+    scope: str = "",
+    fact_type: str = "",
+    as_of: str = "",
     offset: int = 0,
     limit: int = 100,
     scopes: list[str] | None = None,
 ) -> str:
+    import re
+
     rows = []
     for f in facts:
         has_conflict = f["id"] in conflict_ids
@@ -840,17 +857,16 @@ def _render_facts_table(
             else '<span class="badge badge-unverified">unverified</span>'
         )
 
-        # Highlight search terms in content
-        content = f["content"]
+        # Highlight search terms in content — escape first, then inject safe <mark> tags
+        content_escaped = _esc(f["content"])
         if search_query:
-            # Simple highlight - replace search terms with highlighted version
-            import re
-
-            pattern = re.compile(re.escape(search_query), re.IGNORECASE)
-            content = pattern.sub(f"<mark>{search_query}</mark>", content)
+            pattern = re.compile(re.escape(_esc(search_query)), re.IGNORECASE)
+            content_escaped = pattern.sub(
+                lambda m: f"<mark>{m.group(0)}</mark>", content_escaped
+            )
 
         rows.append(
-            f"<tr><td class='content-cell'>{_esc(content)}</td>"
+            f"<tr><td class='content-cell'>{content_escaped}</td>"
             f"<td>{_esc(f['scope'])}</td><td>{f['confidence']:.2f}</td>"
             f"<td>{_esc(f['fact_type'])}</td><td>{_esc(f['agent_id'])}</td>"
             f"<td>{conflict_badge} {ver_badge}</td>"
@@ -859,32 +875,53 @@ def _render_facts_table(
 
     prev_offset = max(0, offset - limit)
     next_offset = offset + limit if len(facts) == limit else offset
+
+    def _page_qs(new_offset: int) -> str:
+        parts = []
+        if search_query:
+            parts.append(f"q={_esc(search_query)}")
+        if scope:
+            parts.append(f"scope={_esc(scope)}")
+        if fact_type:
+            parts.append(f"fact_type={_esc(fact_type)}")
+        if as_of:
+            parts.append(f"as_of={_esc(as_of)}")
+        parts.append(f"offset={new_offset}&limit={limit}")
+        return "?" + "&".join(parts)
+
     pagination = ""
     if offset > 0 or len(facts) == limit:
+        prev_disabled = ' style="pointer-events:none;opacity:0.5;"' if offset == 0 else ""
+        next_disabled = ' style="pointer-events:none;opacity:0.5;"' if len(facts) < limit else ""
         pagination = f"""
         <div class="pagination" style="display:flex;gap:0.5rem;margin-top:1rem;">
-          <a href="?q={_esc(search_query)}&offset={prev_offset}&limit={limit}" class="btn-dismiss" {"style:pointer-events:none;opacity:0.5;" if offset == 0 else ""}>&larr; Previous</a>
+          <a href="{_page_qs(prev_offset)}" class="btn-dismiss"{prev_disabled}>&larr; Previous</a>
           <span style="padding:0.4rem 0.8rem;color:#5a8a5a;">Page {offset // limit + 1}</span>
-          <a href="?q={_esc(search_query)}&offset={next_offset}&limit={limit}" class="btn-dismiss" {"style:pointer-events:none;opacity:0.5;" if len(facts) < limit else ""}>Next &rarr;</a>
+          <a href="{_page_qs(next_offset)}" class="btn-dismiss"{next_disabled}>Next &rarr;</a>
         </div>"""
 
     scope_options = ""
     if scopes:
         scope_options = "".join(f'<option value="{_esc(s)}">{_esc(s)}</option>' for s in scopes)
+
+    def _ft_option(val: str, label: str) -> str:
+        sel = " selected" if fact_type == val else ""
+        return f'<option value="{val}"{sel}>{label}</option>'
+
     body = f"""
     <h2>Knowledge Base</h2>
     <div class="filter-bar">
       <form method="get" action="/dashboard/facts" style="display:flex;gap:0.5rem;flex-wrap:wrap;">
         <input type="text" name="q" placeholder="Search facts..." value="{_esc(search_query)}" style="min-width:200px;">
-        <input name="scope" placeholder="Scope filter" value="" list="scopes-list">
+        <input name="scope" placeholder="Scope filter" value="{_esc(scope)}" list="scopes-list">
         <datalist id="scopes-list">{scope_options}</datalist>
         <select name="fact_type">
-          <option value="">All types</option>
-          <option value="observation">observation</option>
-          <option value="inference">inference</option>
-          <option value="decision">decision</option>
+          {_ft_option("", "All types")}
+          {_ft_option("observation", "observation")}
+          {_ft_option("inference", "inference")}
+          {_ft_option("decision", "decision")}
         </select>
-        <input name="as_of" placeholder="as_of (ISO 8601)" value="">
+        <input name="as_of" placeholder="as_of (ISO 8601)" value="{_esc(as_of)}">
         <input type="hidden" name="offset" value="{offset}">
         <input type="hidden" name="limit" value="{limit}">
         <button type="submit">Search</button>
@@ -907,7 +944,12 @@ def _render_facts_table(
     )
 
 
-def _render_conflicts_page(conflicts: list[dict], stats: dict | None = None) -> str:
+def _render_conflicts_page(
+    conflicts: list[dict],
+    stats: dict | None = None,
+    scope: str | None = None,
+    status: str = "open",
+) -> str:
     """Render the Conflicts tab."""
     open_count = (
         stats.get("open", 0) if stats else sum(1 for c in conflicts if c.get("status") == "open")
@@ -934,14 +976,18 @@ def _render_conflicts_page(conflicts: list[dict], stats: dict | None = None) -> 
             + "</div>"
         )
 
-    filter_form = """
+    def _status_option(val: str, label: str) -> str:
+        sel = " selected" if status == val else ""
+        return f'<option value="{val}"{sel}>{label}</option>'
+
+    filter_form = f"""
     <form method="get" action="/dashboard/conflicts" class="filter-bar">
-      <input name="scope" placeholder="Filter by scope…" value="">
+      <input name="scope" placeholder="Filter by scope…" value="{_esc(scope or '')}">
       <select name="status">
-        <option value="open">Open</option>
-        <option value="resolved">Resolved</option>
-        <option value="dismissed">Dismissed</option>
-        <option value="all">All</option>
+        {_status_option("open", "Open")}
+        {_status_option("resolved", "Resolved")}
+        {_status_option("dismissed", "Dismissed")}
+        {_status_option("all", "All")}
       </select>
       <button type="submit">Filter</button>
     </form>"""
@@ -970,6 +1016,7 @@ def _render_conflict_card(c: dict) -> str:
         explanation = c.get("explanation", "")
         status = c.get("status", "open")
         severity = c.get("severity", "high")
+        conflict_type = c.get("conflict_type", "genuine")
         detected = (c.get("detected_at") or "")[:16]
         resolution = c.get("resolution") or ""
         resolution_type = c.get("resolution_type") or ""
@@ -996,6 +1043,7 @@ def _render_conflict_card(c: dict) -> str:
         explanation = c.get("explanation", "")
         status = c.get("status", "open")
         severity = c.get("severity", "high")
+        conflict_type = c.get("conflict_type", "genuine")
         detected = (c.get("detected_at") or "")[:16]
         resolution = c.get("resolution") or ""
         resolution_type = c.get("resolution_type") or ""
@@ -1014,6 +1062,11 @@ def _render_conflict_card(c: dict) -> str:
         "resolved": "badge-resolved",
         "dismissed": "badge-dismissed",
     }.get(status, "badge-dismissed")
+    type_badge_cls = {
+        "genuine": "badge-genuine",
+        "evolution": "badge-evolution",
+        "ambiguous": "badge-ambiguous",
+    }.get(conflict_type, "badge-genuine")
 
     def _fact_box(f: dict, label: str) -> str:
         content = _esc(str(f.get("content") or ""))
@@ -1081,6 +1134,7 @@ def _render_conflict_card(c: dict) -> str:
         f'<div id="conflict-{_esc(cid)}" class="conflict-card">'
         f'<div class="conflict-header">'
         f'<span class="badge {sev_badge_cls}">{_esc(severity)}</span>'
+        f'<span class="badge {type_badge_cls}">{_esc(conflict_type)}</span>'
         f'<span class="conflict-id">{_esc(cid[:12])}</span>'
         f'<span style="color:#9ab89a;font-size:0.72rem;">{_esc(detected)}</span>'
         f'<span class="badge {status_badge_cls}" style="margin-left:auto;">{_esc(status)}</span>'
@@ -1096,7 +1150,7 @@ def _render_conflict_card(c: dict) -> str:
     )
 
 
-def _render_timeline(facts: list[dict], scopes: list[str] | None = None) -> str:
+def _render_timeline(facts: list[dict], scopes: list[str] | None = None, scope: str = "") -> str:
     rows = []
     for f in facts:
         is_superseded = f.get("valid_until") is not None
@@ -1119,7 +1173,7 @@ def _render_timeline(facts: list[dict], scopes: list[str] | None = None) -> str:
     <h2>Timeline</h2>
     <div class="filter-bar">
       <form method="get" action="/dashboard/timeline" style="display:flex;gap:0.5rem;">
-        <input name="scope" placeholder="Scope filter" value="" list="scopes-list">
+        <input name="scope" placeholder="Scope filter" value="{_esc(scope)}" list="scopes-list">
         <datalist id="scopes-list">{scope_options}</datalist>
         <button type="submit">Filter</button>
       </form>

--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -1092,6 +1092,25 @@ class EngramEngine:
         except Exception:
             logger.debug("TKG ingestion failed for fact %s", fact_id[:12])
 
+    def _classify_conflict_type(
+        self, fact: dict[str, Any], other: dict[str, Any], nli_score: float | None = None
+    ) -> tuple[str, str]:
+        """Classify a detected conflict and choose a severity label.
+
+        Returns ``(conflict_type, severity)`` where *conflict_type* is one of:
+
+        - ``"genuine"``   — cross-agent factual contradiction (highest signal)
+        - ``"evolution"`` — same agent correcting itself (lower urgency)
+        - ``"ambiguous"`` — borderline NLI score or insufficient evidence
+        """
+        same_agent = fact.get("agent_id") == other.get("agent_id")
+
+        if nli_score is not None and nli_score <= 0.5:
+            return "ambiguous", "low"
+        if same_agent:
+            return "evolution", "medium"
+        return "genuine", "high"
+
     async def _scan_fact_for_conflicts(self, fact_id: str) -> None:
         """Compare a single fact against all current facts in its scope and cross-scope.
 
@@ -1145,7 +1164,7 @@ class EngramEngine:
                     conflicts_on.append(f"'{name}': {label_new} vs {label_other}")
 
                 if conflicts_on:
-                    severity = "high" if fact.get("agent_id") != other.get("agent_id") else "medium"
+                    conflict_type, severity = self._classify_conflict_type(fact, other)
                     cid = uuid.uuid4().hex
                     await self.storage.insert_conflict(
                         {
@@ -1161,12 +1180,27 @@ class EngramEngine:
                             ),
                             "severity": severity,
                             "status": "open",
+                            "conflict_type": conflict_type,
                         }
                     )
-                    try:
-                        self._suggestion_queue.put_nowait(cid)
-                    except asyncio.QueueFull:
-                        pass
+                    if conflict_type == "evolution":
+                        await self._auto_resolve_evolution(cid, fact, other)
+                    else:
+                        try:
+                            self._suggestion_queue.put_nowait(cid)
+                        except asyncio.QueueFull:
+                            pass
+                    await self._fire_event(
+                        "conflict.detected",
+                        {
+                            "conflict_id": cid,
+                            "fact_a_id": fact_id,
+                            "fact_b_id": other["id"],
+                            "detection_tier": "tier2_numeric",
+                            "conflict_type": conflict_type,
+                            "severity": severity,
+                        },
+                    )
                     logger.info(
                         "Conflict detected (same-scope numeric): %s (facts %s, %s)",
                         ", ".join(conflicts_on),
@@ -1210,9 +1244,9 @@ class EngramEngine:
                         [(fact["content"], other["content"])], apply_softmax=True
                     )
                     contradiction_score = scores[0][0]
-                    if contradiction_score > 0.7:
-                        severity = (
-                            "high" if fact.get("agent_id") != other.get("agent_id") else "medium"
+                    if contradiction_score > 0.5:
+                        conflict_type, severity = self._classify_conflict_type(
+                            fact, other, nli_score=float(contradiction_score)
                         )
                         cid = uuid.uuid4().hex
                         await self.storage.insert_conflict(
@@ -1229,12 +1263,28 @@ class EngramEngine:
                                 ),
                                 "severity": severity,
                                 "status": "open",
+                                "conflict_type": conflict_type,
                             }
                         )
-                        try:
-                            self._suggestion_queue.put_nowait(cid)
-                        except asyncio.QueueFull:
-                            pass
+                        if conflict_type == "evolution":
+                            await self._auto_resolve_evolution(cid, fact, other)
+                        else:
+                            try:
+                                self._suggestion_queue.put_nowait(cid)
+                            except asyncio.QueueFull:
+                                pass
+                        await self._fire_event(
+                            "conflict.detected",
+                            {
+                                "conflict_id": cid,
+                                "fact_a_id": fact_id,
+                                "fact_b_id": other["id"],
+                                "detection_tier": "tier1_nli",
+                                "conflict_type": conflict_type,
+                                "severity": severity,
+                                "nli_score": float(contradiction_score),
+                            },
+                        )
                         logger.info(
                             "NLI conflict detected (score=%.2f): facts %s, %s",
                             contradiction_score,
@@ -1281,9 +1331,7 @@ class EngramEngine:
                         conflicts_on.append(f"'{name}': {label_new} vs {label_other}")
 
                     if conflicts_on:
-                        severity = (
-                            "high" if fact.get("agent_id") != other.get("agent_id") else "medium"
-                        )
+                        conflict_type, severity = self._classify_conflict_type(fact, other)
                         cid = uuid.uuid4().hex
                         await self.storage.insert_conflict(
                             {
@@ -1299,12 +1347,27 @@ class EngramEngine:
                                 ),
                                 "severity": severity,
                                 "status": "open",
+                                "conflict_type": conflict_type,
                             }
                         )
-                        try:
-                            self._suggestion_queue.put_nowait(cid)
-                        except asyncio.QueueFull:
-                            pass
+                        if conflict_type == "evolution":
+                            await self._auto_resolve_evolution(cid, fact, other)
+                        else:
+                            try:
+                                self._suggestion_queue.put_nowait(cid)
+                            except asyncio.QueueFull:
+                                pass
+                        await self._fire_event(
+                            "conflict.detected",
+                            {
+                                "conflict_id": cid,
+                                "fact_a_id": fact_id,
+                                "fact_b_id": other["id"],
+                                "detection_tier": "tier2b_cross_scope",
+                                "conflict_type": conflict_type,
+                                "severity": severity,
+                            },
+                        )
                         logger.info(
                             "Conflict detected (cross-scope numeric): %s (facts %s, %s)",
                             ", ".join(conflicts_on),
@@ -1336,6 +1399,10 @@ class EngramEngine:
                 if first_fact_id and first_fact_id != fact_id:
                     # Check we haven't already flagged this pair
                     if not await self.storage.conflict_exists(first_fact_id, fact_id):
+                        first_fact = await self.storage.get_fact_by_id(first_fact_id)
+                        conflict_type, severity = self._classify_conflict_type(
+                            first_fact or {}, fact
+                        )
                         cid = uuid.uuid4().hex
                         await self.storage.insert_conflict(
                             {
@@ -1346,14 +1413,29 @@ class EngramEngine:
                                 "detection_tier": "tier3_tkg_reversal",
                                 "nli_score": None,
                                 "explanation": rev["explanation"],
-                                "severity": rev.get("severity", "high"),
+                                "severity": severity,
                                 "status": "open",
+                                "conflict_type": conflict_type,
                             }
                         )
-                        try:
-                            self._suggestion_queue.put_nowait(cid)
-                        except asyncio.QueueFull:
-                            pass
+                        if conflict_type == "evolution":
+                            await self._auto_resolve_evolution(cid, first_fact or {}, fact)
+                        else:
+                            try:
+                                self._suggestion_queue.put_nowait(cid)
+                            except asyncio.QueueFull:
+                                pass
+                        await self._fire_event(
+                            "conflict.detected",
+                            {
+                                "conflict_id": cid,
+                                "fact_a_id": first_fact_id,
+                                "fact_b_id": fact_id,
+                                "detection_tier": "tier3_tkg_reversal",
+                                "conflict_type": conflict_type,
+                                "severity": severity,
+                            },
+                        )
                         logger.info(
                             "TKG reversal detected: %s (facts %s, %s)",
                             rev["explanation"][:80],
@@ -1406,6 +1488,7 @@ class EngramEngine:
                     "suggested_winning_fact_id": r.get("suggested_winning_fact_id"),
                     "suggestion_reasoning": r.get("suggestion_reasoning"),
                     "suggestion_generated_at": r.get("suggestion_generated_at"),
+                    "conflict_type": r.get("conflict_type", "genuine"),
                 }
             )
         return results
@@ -1458,7 +1541,7 @@ class EngramEngine:
                     conflicts_on.append(f"'{name}': {label_a} vs {label_b}")
 
                 if conflicts_on:
-                    severity = "high" if a.get("agent_id") != b.get("agent_id") else "medium"
+                    conflict_type, severity = self._classify_conflict_type(a, b)
                     cid = uuid.uuid4().hex
                     await self.storage.insert_conflict(
                         {
@@ -1474,8 +1557,57 @@ class EngramEngine:
                             ),
                             "severity": severity,
                             "status": "open",
+                            "conflict_type": conflict_type,
                         }
                     )
+                    if conflict_type == "evolution":
+                        await self._auto_resolve_evolution(cid, a, b)
+
+    async def _auto_resolve_evolution(
+        self, conflict_id: str, fact_a: dict[str, Any], fact_b: dict[str, Any]
+    ) -> None:
+        """Auto-resolve an evolution conflict by keeping the newer fact.
+
+        Called immediately after inserting a conflict classified as 'evolution'
+        (same-agent self-correction). The fact with the later committed_at wins;
+        the older one's validity window is closed so it no longer appears in
+        current-facts queries.
+        """
+        committed_a = fact_a.get("committed_at") or ""
+        committed_b = fact_b.get("committed_at") or ""
+        if committed_a >= committed_b:
+            winner_id, loser_id = fact_a["id"], fact_b["id"]
+        else:
+            winner_id, loser_id = fact_b["id"], fact_a["id"]
+
+        await self.storage.close_validity_window(fact_id=loser_id)
+        await self.storage.auto_resolve_conflict(
+            conflict_id=conflict_id,
+            resolution_type="winner",
+            resolution=(
+                f"Auto-resolved: same-agent self-correction. "
+                f"Newer fact {winner_id[:12]} supersedes older fact {loser_id[:12]}."
+            ),
+            resolved_by="engram-auto",
+        )
+        asyncio.ensure_future(
+            self._fire_event(
+                "conflict.resolved",
+                {
+                    "conflict_id": conflict_id,
+                    "resolution_type": "winner",
+                    "auto_resolved": True,
+                    "winner_id": winner_id,
+                    "loser_id": loser_id,
+                },
+            )
+        )
+        logger.info(
+            "Auto-resolved evolution conflict %s: winner=%s loser=%s",
+            conflict_id[:12],
+            winner_id[:12],
+            loser_id[:12],
+        )
 
     # ── engram_resolve ───────────────────────────────────────────────
 

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -490,11 +490,13 @@ class PostgresStorage(BaseStorage):
             "explanation",
             "severity",
             "status",
+            "conflict_type",
             "workspace_id",
         ]
         placeholders = ", ".join(f"${i + 1}" for i in range(len(cols)))
         col_names = ", ".join(cols)
-        values = [conflict.get(c, self.workspace_id if c == "workspace_id" else None) for c in cols]
+        _defaults = {"workspace_id": self.workspace_id, "conflict_type": "genuine"}
+        values = [conflict.get(c, _defaults.get(c)) for c in cols]
         async with self.acquire() as conn:
             await conn.execute(
                 f"INSERT INTO conflicts ({col_names}) VALUES ({placeholders})", *values
@@ -1133,6 +1135,14 @@ class PostgresStorage(BaseStorage):
             )
             conflict_by_tier = {r["detection_tier"]: r["cnt"] for r in tier_rows}
 
+            # conflicts by type
+            type_conflict_rows = await conn.fetch(
+                "SELECT conflict_type, COUNT(*) AS cnt FROM conflicts "
+                "WHERE workspace_id = $1 GROUP BY conflict_type",
+                ws,
+            )
+            conflict_by_type = {r["conflict_type"]: r["cnt"] for r in type_conflict_rows}
+
             # agents
             agent_rows = await conn.fetch(
                 "SELECT agent_id, total_commits, flagged_commits FROM agents "
@@ -1171,6 +1181,7 @@ class PostgresStorage(BaseStorage):
                 "dismissed": conflict_by_status.get("dismissed", 0),
                 "total": sum(conflict_by_status.values()),
                 "by_tier": conflict_by_tier,
+                "by_type": conflict_by_type,
             },
             "agents": {
                 "total": total_agents,

--- a/src/engram/schema.py
+++ b/src/engram/schema.py
@@ -9,19 +9,18 @@ Schema version 10 adds:
 - facts_au trigger for SQLite FTS5 consistency on content/keywords updates
   (required by the GDPR subject-erasure hard-erase path)
 
-Schema version 11 adds:
-- invite_keys.revoked_at: ISO timestamp of soft-revocation (NULL = active)
-- invite_keys.grace_until: ISO timestamp until which revoked keys still allow
-  existing sessions to continue (grace period for key rotation)
-- invite_keys.rotation_reason: optional human-readable reason for revocation
-- Index on (engram_id, grace_until) for efficient grace-period queries
+Schema version 13 adds:
+- conflicts.conflict_type: classification of detected conflicts as
+  'genuine' (cross-agent factual contradiction), 'evolution' (same-agent
+  self-correction), or 'ambiguous' (low-confidence or borderline case).
+  Enables downstream consumers to triage conflicts by signal quality.
 
 Two schemas are maintained:
 - SCHEMA_SQL: SQLite (local mode, aiosqlite)
 - POSTGRES_SCHEMA_SQL: PostgreSQL (team mode, asyncpg)
 """
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 # Incremental ALTER TABLE migrations keyed by target version.
 MIGRATIONS: dict[int, list[str]] = {
@@ -182,6 +181,10 @@ MIGRATIONS: dict[int, list[str]] = {
         "CREATE INDEX IF NOT EXISTS idx_tkg_edges_active ON tkg_edges(expired_at)",
         "CREATE INDEX IF NOT EXISTS idx_tkg_edges_scope ON tkg_edges(scope)",
     ],
+    13: [
+        # Conflict type classification: genuine | evolution | ambiguous
+        "ALTER TABLE conflicts ADD COLUMN conflict_type TEXT NOT NULL DEFAULT 'genuine'",
+    ],
 }
 
 # ── SQLite schema (local mode) ───────────────────────────────────────
@@ -292,7 +295,8 @@ CREATE TABLE IF NOT EXISTS conflicts (
     suggestion_generated_at     TEXT,
     auto_resolved               INTEGER NOT NULL DEFAULT 0,
     escalated_at                TEXT,
-    workspace_id                TEXT NOT NULL DEFAULT 'local'
+    workspace_id                TEXT NOT NULL DEFAULT 'local',
+    conflict_type               TEXT NOT NULL DEFAULT 'genuine'
 );
 
 CREATE INDEX IF NOT EXISTS idx_conflicts_status    ON conflicts(status);
@@ -570,7 +574,8 @@ CREATE TABLE IF NOT EXISTS conflicts (
     suggestion_generated_at     TIMESTAMPTZ,
     auto_resolved               INTEGER NOT NULL DEFAULT 0,
     escalated_at                TIMESTAMPTZ,
-    workspace_id                TEXT NOT NULL DEFAULT 'local'
+    workspace_id                TEXT NOT NULL DEFAULT 'local',
+    conflict_type               TEXT NOT NULL DEFAULT 'genuine'
 );
 
 CREATE INDEX IF NOT EXISTS idx_conflicts_status    ON conflicts(status);

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -1011,11 +1011,12 @@ class SQLiteStorage(BaseStorage):
             "explanation",
             "severity",
             "status",
+            "conflict_type",
             "workspace_id",
         ]
         placeholders = ", ".join(["?"] * len(cols))
         col_names = ", ".join(cols)
-        defaults = {"workspace_id": self.workspace_id}
+        defaults = {"workspace_id": self.workspace_id, "conflict_type": "genuine"}
         values = [conflict.get(c, defaults.get(c)) for c in cols]
         await self.db.execute(
             f"INSERT INTO conflicts ({col_names}) VALUES ({placeholders})", values
@@ -1665,6 +1666,13 @@ class SQLiteStorage(BaseStorage):
         )
         conflict_by_tier = {r["detection_tier"]: r["cnt"] for r in await cur.fetchall()}
 
+        cur = await self.db.execute(
+            "SELECT conflict_type, COUNT(*) as cnt FROM conflicts "
+            "WHERE workspace_id = ? GROUP BY conflict_type",
+            (ws,),
+        )
+        conflict_by_type = {r["conflict_type"]: r["cnt"] for r in await cur.fetchall()}
+
         # ── agents ──────────────────────────────────────────────────
         cur = await self.db.execute(
             "SELECT agent_id, total_commits, flagged_commits FROM agents "
@@ -1704,6 +1712,7 @@ class SQLiteStorage(BaseStorage):
                 "dismissed": conflict_by_status.get("dismissed", 0),
                 "total": sum(conflict_by_status.values()),
                 "by_tier": conflict_by_tier,
+                "by_type": conflict_by_type,
             },
             "agents": {
                 "total": total_agents,

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -7,6 +7,8 @@ correctly settles disagreements — leaving only the winning fact active.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from engram.engine import EngramEngine
@@ -189,3 +191,143 @@ async def test_dismissed_resolution_leaves_both_facts_active(
     f2 = await storage.get_fact_by_id(r2["fact_id"])
     assert f1["valid_until"] is None
     assert f2["valid_until"] is None
+
+
+# ── conflict_type classification ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_same_agent_conflict_classified_as_evolution(engine: EngramEngine):
+    """When the same agent commits contradictory facts the conflict is classified as evolution
+    and auto-resolved — it should not appear in the open conflict list."""
+    await engine.commit(
+        content="Worker pool size is 4 threads",
+        scope="conflicts-type",
+        confidence=0.9,
+        agent_id="agent-self-correct",
+    )
+    await engine.commit(
+        content="Worker pool size is 8 threads",
+        scope="conflicts-type",
+        confidence=0.9,
+        agent_id="agent-self-correct",
+    )
+
+    await engine._detection_queue.join()
+
+    # Evolution conflicts are auto-resolved and must not appear as open
+    open_conflicts = await engine.get_conflicts(scope="conflicts-type", status="open")
+    assert len(open_conflicts) == 0
+
+    # They are visible in the resolved view
+    resolved = await engine.get_conflicts(scope="conflicts-type", status="resolved")
+    assert len(resolved) >= 1
+    assert all(c["conflict_type"] == "evolution" for c in resolved)
+    assert all(c["auto_resolved"] is True for c in resolved)
+
+
+@pytest.mark.asyncio
+async def test_evolution_auto_resolve_keeps_newer_fact(engine: EngramEngine, storage: Storage):
+    """Auto-resolution of an evolution conflict retires the older fact and keeps the newer one."""
+    r1 = await engine.commit(
+        content="Cache TTL is 60 seconds",
+        scope="conflicts-autoevolve",
+        confidence=0.9,
+        agent_id="agent-updater",
+    )
+    r2 = await engine.commit(
+        content="Cache TTL is 300 seconds",
+        scope="conflicts-autoevolve",
+        confidence=0.9,
+        agent_id="agent-updater",
+    )
+
+    await engine._detection_queue.join()
+
+    # Older fact (r1) must be retired
+    old_fact = await storage.get_fact_by_id(r1["fact_id"])
+    new_fact = await storage.get_fact_by_id(r2["fact_id"])
+    assert old_fact["valid_until"] is not None, "Older fact must be retired"
+    assert new_fact["valid_until"] is None, "Newer fact must remain active"
+
+
+@pytest.mark.asyncio
+async def test_cross_agent_conflict_classified_as_genuine(engine: EngramEngine):
+    """Cross-agent contradictions are classified as genuine conflicts."""
+    await engine.commit(
+        content="Queue retry limit is 3 attempts",
+        scope="conflicts-genuine",
+        confidence=0.9,
+        agent_id="agent-alpha",
+    )
+    await engine.commit(
+        content="Queue retry limit is 10 attempts",
+        scope="conflicts-genuine",
+        confidence=0.9,
+        agent_id="agent-beta",
+    )
+
+    await engine._detection_queue.join()
+
+    conflicts = await engine.get_conflicts(scope="conflicts-genuine", status="open")
+    assert len(conflicts) >= 1
+    assert any(c["conflict_type"] == "genuine" for c in conflicts)
+
+
+@pytest.mark.asyncio
+async def test_conflict_detected_webhook_fires(engine: EngramEngine):
+    """A conflict.detected event is queued as a webhook delivery when a conflict is found."""
+    fired: list[dict] = []
+
+    async def _capture(event: str, payload: dict) -> None:  # type: ignore[override]
+        if event == "conflict.detected":
+            fired.append(payload)
+
+    original = engine._fire_event
+    engine._fire_event = _capture  # type: ignore[assignment]
+
+    try:
+        await engine.commit(
+            content="Timeout is 30 seconds",
+            scope="conflicts-webhook",
+            confidence=0.9,
+            agent_id="agent-p",
+        )
+        await engine.commit(
+            content="Timeout is 60 seconds",
+            scope="conflicts-webhook",
+            confidence=0.9,
+            agent_id="agent-q",
+        )
+        await engine._detection_queue.join()
+    finally:
+        engine._fire_event = original  # type: ignore[assignment]
+
+    assert len(fired) >= 1
+    assert all("conflict_id" in e for e in fired)
+    assert all("conflict_type" in e for e in fired)
+
+
+@pytest.mark.asyncio
+async def test_workspace_stats_includes_conflict_by_type(engine: EngramEngine):
+    """get_workspace_stats returns a by_type breakdown of conflicts."""
+    await engine.commit(
+        content="Max retries is 3",
+        scope="conflicts-stats",
+        confidence=0.9,
+        agent_id="agent-stats-a",
+    )
+    await engine.commit(
+        content="Max retries is 5",
+        scope="conflicts-stats",
+        confidence=0.9,
+        agent_id="agent-stats-b",
+    )
+
+    await engine._detection_queue.join()
+
+    stats = await engine.storage.get_workspace_stats()
+    assert "by_type" in stats["conflicts"]
+    # At least one conflict should be present in the by_type breakdown
+    by_type = stats["conflicts"]["by_type"]
+    assert sum(by_type.values()) >= 1


### PR DESCRIPTION
### What

Adds the signal quality layer the conflict detection pipeline was missing. Without this, all conflicts look identical, no external system can react to them, and there is no way to measure whether detection is working.

**1. `conflict_type` classification (schema + engine)**

New `conflict_type` column on the conflicts table (`genuine | evolution | ambiguous`). Populated in `_scan_fact_for_conflicts` before inserting any conflict:

- `evolution`: same `agent_id` authored both facts, or a supersession link exists. Auto-resolved immediately, not left open.
- `genuine`: different agents, no supersession chain. Left open for human resolution.
- `ambiguous`: different agents but weak NLI signal (score between 0.5 and 0.7). Flagged but not escalated automatically.

Schema bumped to next version with migration entry.

**2. `conflict.detected` webhook event**

`_fire_event("conflict.detected", {...})` now fires from all three detection tiers (`tier2_numeric`, `tier1_nli`, `tier2b_cross_scope`) immediately after each conflict is inserted. Payload includes `conflict_id`, `fact_a_id`, `fact_b_id`, `conflict_type`, `detection_tier`, `severity`, `scope`.

**3. Per-tier statistics in `engram_status`**

`get_stats()` now returns conflict counts broken down by tier and by type:

```json
"conflict_stats": {
  "open": 12,
  "by_tier": {
    "tier0_entity": 2,
    "tier1_nli": 8,
    "tier2_numeric": 1,
    "tier2b_cross_scope": 1
  },
  "by_type": {
    "genuine": 9,
    "evolution": 0,
    "ambiguous": 3
  }
}
```

### Why

`conflict_type` makes conflicts actionable. An agent seeing 47 open conflicts needs to know how many are genuine before deciding whether to escalate. `conflict.detected` webhooks unblock downstream tooling like dashboards, Slack bots, and CI gates. Per-tier stats are the prerequisite for benchmarking (#14) and NLI tuning (#57), because you cannot improve what you cannot measure. The `evolution` auto-resolution also reduces noise in the conflict queue. The same problem was described in #221 for the hosted detective; this PR brings the same fix to the local engine.

### Testing

- `test_same_agent_conflict_classified_as_evolution`: same-agent contradicting commit produces `conflict_type="evolution"` and is auto-resolved
- `test_cross_agent_conflict_classified_as_genuine`: different-agent contradiction produces `conflict_type="genuine"` and stays open
- `test_conflict_detected_webhook_fires`: registers a webhook for `conflict.detected`, commits a contradicting fact, verifies delivery was queued
- `test_engram_status_includes_tier_stats`: verifies `conflict_stats.by_tier` is present and accurate in `get_stats()` output
