### PR TITLE
Add LangChain memory adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Engram works with any AI coding environment. First-class support for:
 
 Agents without MCP support connect via the REST API using the credentials in `.engram.env`. Instructions are in `AGENTS.md` at the root of every Engram-enabled repo.
 
+Framework integrations:
+
+- [LangChain / LangGraph](./docs/integrations/langchain.md)
+
 ---
 
 ## CLI Reference

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,0 +1,81 @@
+# LangChain / LangGraph Integration
+
+Engram can be used from LangChain and LangGraph workflows through the HTTP API.
+This does not require MCP.
+
+Start a local Engram HTTP server:
+
+```bash
+engram serve --http
+```
+
+## REST Client
+
+Use the lightweight client when you want direct control from any Python pipeline:
+
+```python
+from engram.client import EngramClient
+
+client = EngramClient(base_url="http://127.0.0.1:7474")
+
+facts = client.query("How does auth work?", scope="auth")
+client.commit(
+    "Auth uses JWT session tokens",
+    scope="auth",
+    confidence=0.9,
+    provenance="docs/auth.md",
+)
+```
+
+## LangChain Memory
+
+Install LangChain's core package if your environment does not already include it:
+
+```bash
+pip install langchain-core
+```
+
+Then use `EngramMemory` as a LangChain memory object:
+
+```python
+from engram.integrations.langchain import EngramMemory
+
+memory = EngramMemory(
+    base_url="http://127.0.0.1:7474",
+    scope="auth",
+    memory_key="engram_memory",
+)
+
+context = memory.load_memory_variables({"input": "How does auth work?"})
+print(context["engram_memory"])
+```
+
+`EngramMemory` reads relevant workspace facts into the chain context. It does
+not automatically commit chat transcripts. Commit only verified facts:
+
+```python
+memory.commit_fact(
+    "The auth service validates JWTs on every request",
+    scope="auth",
+    confidence=0.9,
+)
+```
+
+## LangGraph
+
+LangGraph has its own checkpointing and persistence model. For v1, use the
+Engram REST client inside graph nodes when a node needs team memory:
+
+```python
+from engram.client import EngramClient
+
+client = EngramClient(base_url="http://127.0.0.1:7474")
+
+
+def retrieve_team_memory(state):
+    facts = client.query(state["task"], scope=state.get("scope"), limit=5)
+    return {"engram_memory": facts}
+```
+
+Keep checkpoint state and Engram memory separate: checkpoints store graph state;
+Engram stores verified team facts.

--- a/src/engram/client.py
+++ b/src/engram/client.py
@@ -1,0 +1,167 @@
+"""Small REST client for Engram's HTTP API."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class EngramClientError(RuntimeError):
+    """Raised when the Engram REST API returns an error or invalid response."""
+
+
+class EngramClient:
+    """Thin synchronous client for Engram's REST API.
+
+    The client intentionally uses the standard library so integrations can use
+    Engram without adding another required HTTP dependency.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:7474",
+        *,
+        api_key: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def query(
+        self,
+        topic: str,
+        *,
+        scope: str | None = None,
+        limit: int = 10,
+        as_of: str | None = None,
+        fact_type: str | None = None,
+        agent_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query Engram memory for facts relevant to a topic."""
+        payload: dict[str, Any] = {"topic": topic, "limit": limit}
+        if scope:
+            payload["scope"] = scope
+        if as_of:
+            payload["as_of"] = as_of
+        if fact_type:
+            payload["fact_type"] = fact_type
+        if agent_id:
+            payload["agent_id"] = agent_id
+        result = self._request_json("POST", "/api/query", payload)
+        if not isinstance(result, list):
+            raise EngramClientError("Expected /api/query to return a JSON list.")
+        return result
+
+    def commit(
+        self,
+        content: str,
+        *,
+        scope: str = "general",
+        confidence: float = 0.8,
+        agent_id: str | None = None,
+        engineer: str | None = None,
+        provenance: str | None = None,
+        fact_type: str = "observation",
+        ttl_days: int | None = None,
+        operation: str = "add",
+    ) -> dict[str, Any]:
+        """Commit a verified fact to Engram memory."""
+        payload: dict[str, Any] = {
+            "content": content,
+            "scope": scope,
+            "confidence": confidence,
+            "fact_type": fact_type,
+            "operation": operation,
+        }
+        if agent_id:
+            payload["agent_id"] = agent_id
+        if engineer:
+            payload["engineer"] = engineer
+        if provenance:
+            payload["provenance"] = provenance
+        if ttl_days is not None:
+            payload["ttl_days"] = ttl_days
+        result = self._request_json("POST", "/api/commit", payload)
+        if not isinstance(result, dict):
+            raise EngramClientError("Expected /api/commit to return a JSON object.")
+        return result
+
+    def batch_commit(
+        self,
+        facts: list[dict[str, Any]],
+        *,
+        agent_id: str | None = None,
+        engineer: str | None = None,
+    ) -> dict[str, Any]:
+        """Commit multiple verified facts in one request."""
+        payload: dict[str, Any] = {"facts": facts}
+        if agent_id:
+            payload["agent_id"] = agent_id
+        if engineer:
+            payload["engineer"] = engineer
+        result = self._request_json("POST", "/api/batch-commit", payload)
+        if not isinstance(result, dict):
+            raise EngramClientError("Expected /api/batch-commit to return a JSON object.")
+        return result
+
+    def conflicts(self, *, scope: str | None = None, status: str = "open") -> list[dict[str, Any]]:
+        """Return Engram conflicts, optionally filtered by scope/status."""
+        params = {"status": status}
+        if scope:
+            params["scope"] = scope
+        path = f"/api/conflicts?{urllib.parse.urlencode(params)}"
+        result = self._request_json("GET", path)
+        if not isinstance(result, list):
+            raise EngramClientError("Expected /api/conflicts to return a JSON list.")
+        return result
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers=headers,
+            method=method,
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                raw = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            raw_error = exc.read().decode("utf-8", errors="replace")
+            raise EngramClientError(
+                _extract_error(raw_error) or f"Engram API error: {exc.code}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise EngramClientError(f"Could not reach Engram API: {exc.reason}") from exc
+
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise EngramClientError("Engram API returned invalid JSON.") from exc
+
+
+def _extract_error(raw_error: str) -> str | None:
+    try:
+        payload = json.loads(raw_error)
+    except json.JSONDecodeError:
+        return raw_error.strip() or None
+    if isinstance(payload, dict):
+        error = payload.get("error") or payload.get("detail")
+        return str(error) if error else None
+    return None

--- a/src/engram/integrations/__init__.py
+++ b/src/engram/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Optional framework integrations for Engram."""

--- a/src/engram/integrations/langchain.py
+++ b/src/engram/integrations/langchain.py
@@ -1,0 +1,151 @@
+"""LangChain memory adapter for Engram."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+from engram.client import EngramClient
+
+try:
+    from langchain_core.memory import BaseMemory
+except ImportError as exc:  # pragma: no cover - exercised through helper tests
+    BaseMemory = object  # type: ignore[assignment,misc]
+    _LANGCHAIN_IMPORT_ERROR = exc
+else:
+    _LANGCHAIN_IMPORT_ERROR = None
+
+
+LANGCHAIN_BASE_MEMORY_AVAILABLE = _LANGCHAIN_IMPORT_ERROR is None
+
+
+class EngramMemory(BaseMemory):  # type: ignore[misc]
+    """LangChain-compatible memory backed by Engram's REST API.
+
+    The adapter uses LangChain's memory method names and subclasses
+    ``BaseMemory`` when the installed LangChain version still provides it.
+    Recent LangChain releases no longer expose that class, so this remains a
+    lightweight compatible adapter instead of forcing a legacy dependency.
+
+    It does not automatically write chain transcripts back to Engram; use
+    ``commit_fact`` for verified facts.
+    """
+
+    if LANGCHAIN_BASE_MEMORY_AVAILABLE:
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        client: EngramClient = Field(default_factory=EngramClient)
+        scope: str | None = None
+        memory_key: str = "engram_memory"
+        input_key: str = "input"
+        limit: int = 5
+        empty_message: str = "No Engram memory found."
+
+    def __init__(
+        self,
+        *,
+        client: EngramClient | None = None,
+        base_url: str = "http://127.0.0.1:7474",
+        api_key: str | None = None,
+        timeout: float = 30.0,
+        scope: str | None = None,
+        memory_key: str = "engram_memory",
+        input_key: str = "input",
+        limit: int = 5,
+        empty_message: str = "No Engram memory found.",
+    ) -> None:
+        resolved_client = client or EngramClient(
+            base_url=base_url,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        if LANGCHAIN_BASE_MEMORY_AVAILABLE:
+            super().__init__(
+                client=resolved_client,
+                scope=scope,
+                memory_key=memory_key,
+                input_key=input_key,
+                limit=limit,
+                empty_message=empty_message,
+            )
+            return
+        self.client = resolved_client
+        self.scope = scope
+        self.memory_key = memory_key
+        self.input_key = input_key
+        self.limit = limit
+        self.empty_message = empty_message
+
+    @property
+    def memory_variables(self) -> list[str]:
+        return [self.memory_key]
+
+    def load_memory_variables(self, inputs: dict[str, Any]) -> dict[str, str]:
+        topic = self._topic_from_inputs(inputs)
+        if not topic:
+            return {self.memory_key: self.empty_message}
+        facts = self.client.query(topic, scope=self.scope, limit=self.limit)
+        return {self.memory_key: format_facts(facts, empty_message=self.empty_message)}
+
+    async def aload_memory_variables(self, inputs: dict[str, Any]) -> dict[str, str]:
+        return self.load_memory_variables(inputs)
+
+    def save_context(self, inputs: dict[str, Any], outputs: dict[str, Any]) -> None:
+        """No-op by default to avoid committing unverified chat history."""
+        return None
+
+    async def asave_context(self, inputs: dict[str, Any], outputs: dict[str, Any]) -> None:
+        return None
+
+    def clear(self) -> None:
+        """No local state is stored by the adapter."""
+        return None
+
+    async def aclear(self) -> None:
+        return None
+
+    def commit_fact(
+        self,
+        content: str,
+        *,
+        scope: str | None = None,
+        confidence: float = 0.8,
+        fact_type: str = "observation",
+        provenance: str | None = None,
+        agent_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Explicitly commit a verified fact to Engram."""
+        return self.client.commit(
+            content,
+            scope=scope or self.scope or "general",
+            confidence=confidence,
+            fact_type=fact_type,
+            provenance=provenance,
+            agent_id=agent_id,
+        )
+
+    def _topic_from_inputs(self, inputs: dict[str, Any]) -> str:
+        if self.input_key in inputs:
+            return str(inputs[self.input_key])
+        if len(inputs) == 1:
+            return str(next(iter(inputs.values())))
+        return ""
+
+
+def format_facts(
+    facts: list[dict[str, Any]], *, empty_message: str = "No Engram memory found."
+) -> str:
+    """Format Engram query results for prompt injection into a chain."""
+    if not facts:
+        return empty_message
+    lines = []
+    for fact in facts:
+        content = fact.get("content") or ""
+        scope = fact.get("scope") or "general"
+        confidence = fact.get("effective_confidence", fact.get("confidence"))
+        if confidence is None:
+            lines.append(f"- [{scope}] {content}")
+        else:
+            lines.append(f"- [{scope}] {content} (confidence: {float(confidence):.2f})")
+    return "\n".join(lines)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,147 @@
+"""Tests for the Engram REST client."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+
+from engram.client import EngramClient, EngramClientError
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_client_query_posts_expected_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout=30):
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        captured["headers"] = dict(request.header_items())
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return DummyResponse([{"content": "Auth uses JWT", "scope": "auth"}])
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    client = EngramClient(base_url="http://engram.local/", api_key="ek_test", timeout=5)
+    result = client.query("auth tokens", scope="auth", limit=3, agent_id="agent-1")
+
+    assert result == [{"content": "Auth uses JWT", "scope": "auth"}]
+    assert captured["url"] == "http://engram.local/api/query"
+    assert captured["method"] == "POST"
+    assert captured["payload"] == {
+        "topic": "auth tokens",
+        "limit": 3,
+        "scope": "auth",
+        "agent_id": "agent-1",
+    }
+    assert captured["headers"]["Authorization"] == "Bearer ek_test"
+    assert captured["timeout"] == 5
+
+
+def test_client_commit_posts_expected_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout=30):
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return DummyResponse({"fact_id": "fact-1", "duplicate": False})
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    result = EngramClient().commit(
+        "Auth uses JWT",
+        scope="auth",
+        confidence=0.9,
+        fact_type="decision",
+        provenance="docs/auth.md",
+    )
+
+    assert result == {"fact_id": "fact-1", "duplicate": False}
+    assert captured["url"] == "http://127.0.0.1:7474/api/commit"
+    assert captured["method"] == "POST"
+    assert captured["payload"] == {
+        "content": "Auth uses JWT",
+        "scope": "auth",
+        "confidence": 0.9,
+        "fact_type": "decision",
+        "operation": "add",
+        "provenance": "docs/auth.md",
+    }
+
+
+def test_client_batch_commit_posts_expected_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout=30):
+        captured["url"] = request.full_url
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return DummyResponse({"committed": 1, "duplicates": 0})
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    facts = [{"content": "Auth uses JWT", "scope": "auth", "confidence": 0.8}]
+    result = EngramClient().batch_commit(facts, agent_id="agent-1")
+
+    assert result == {"committed": 1, "duplicates": 0}
+    assert captured["url"] == "http://127.0.0.1:7474/api/batch-commit"
+    assert captured["payload"] == {"facts": facts, "agent_id": "agent-1"}
+
+
+def test_client_conflicts_gets_expected_url(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request, timeout=30):
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        return DummyResponse([{"id": "conflict-1"}])
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    result = EngramClient().conflicts(scope="auth", status="resolved")
+
+    assert result == [{"id": "conflict-1"}]
+    assert captured["method"] == "GET"
+    assert captured["url"] == "http://127.0.0.1:7474/api/conflicts?status=resolved&scope=auth"
+
+
+def test_client_raises_api_error(monkeypatch):
+    def fake_urlopen(request, timeout=30):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=DummyErrorBody({"error": "content is required"}),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(EngramClientError, match="content is required"):
+        EngramClient().commit("", scope="auth")
+
+
+class DummyErrorBody:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+    def close(self):
+        return None

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -1,0 +1,118 @@
+"""Tests for the optional LangChain adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from engram.integrations import langchain as langchain_adapter
+from engram.integrations.langchain import format_facts
+
+
+class FakeClient:
+    def __init__(self):
+        self.queries = []
+        self.commits = []
+
+    def query(self, topic, *, scope=None, limit=10):
+        self.queries.append({"topic": topic, "scope": scope, "limit": limit})
+        return [
+            {
+                "content": "Auth uses JWT session tokens",
+                "scope": "auth",
+                "effective_confidence": 0.91,
+            }
+        ]
+
+    def commit(self, content, **kwargs):
+        self.commits.append({"content": content, **kwargs})
+        return {"fact_id": "fact-1", "duplicate": False}
+
+
+def test_format_facts_includes_scope_content_and_confidence():
+    output = format_facts(
+        [
+            {
+                "content": "Auth uses JWT",
+                "scope": "auth",
+                "effective_confidence": 0.91,
+            }
+        ]
+    )
+
+    assert output == "- [auth] Auth uses JWT (confidence: 0.91)"
+
+
+def test_format_facts_handles_empty_results():
+    assert format_facts([]) == "No Engram memory found."
+
+
+def test_memory_loads_variables_when_langchain_available():
+    client = FakeClient()
+    memory = langchain_adapter.EngramMemory(
+        client=client,
+        scope="auth",
+        memory_key="team_memory",
+        input_key="question",
+        limit=2,
+    )
+
+    result = memory.load_memory_variables({"question": "How does auth work?"})
+
+    assert result == {"team_memory": "- [auth] Auth uses JWT session tokens (confidence: 0.91)"}
+    assert client.queries == [{"topic": "How does auth work?", "scope": "auth", "limit": 2}]
+
+
+def test_memory_can_build_client_from_connection_options():
+    memory = langchain_adapter.EngramMemory(
+        base_url="http://engram.local",
+        api_key="ek_test",
+        timeout=3.0,
+    )
+
+    assert memory.client.base_url == "http://engram.local"
+    assert memory.client.api_key == "ek_test"
+    assert memory.client.timeout == 3.0
+
+
+def test_memory_save_context_does_not_commit_when_langchain_available():
+    client = FakeClient()
+    memory = langchain_adapter.EngramMemory(client=client, scope="auth")
+
+    memory.save_context({"input": "remember this"}, {"output": "ok"})
+
+    assert client.commits == []
+
+
+def test_memory_commit_fact_is_explicit_when_langchain_available():
+    client = FakeClient()
+    memory = langchain_adapter.EngramMemory(client=client, scope="auth")
+
+    result = memory.commit_fact(
+        "Auth uses JWT",
+        confidence=0.9,
+        provenance="docs/auth.md",
+        agent_id="agent-1",
+    )
+
+    assert result == {"fact_id": "fact-1", "duplicate": False}
+    assert client.commits == [
+        {
+            "content": "Auth uses JWT",
+            "scope": "auth",
+            "confidence": 0.9,
+            "fact_type": "observation",
+            "provenance": "docs/auth.md",
+            "agent_id": "agent-1",
+        }
+    ]
+
+
+def test_adapter_reports_whether_base_memory_is_available():
+    assert isinstance(langchain_adapter.LANGCHAIN_BASE_MEMORY_AVAILABLE, bool)
+
+
+def test_memory_uses_langchain_base_memory_when_available():
+    if not langchain_adapter.LANGCHAIN_BASE_MEMORY_AVAILABLE:
+        pytest.skip("installed LangChain does not expose BaseMemory")
+
+    assert isinstance(langchain_adapter.EngramMemory(), langchain_adapter.BaseMemory)


### PR DESCRIPTION
## Summary

Adds a focused v1 LangChain integration for Engram using the existing REST API.

This PR introduces:
- a thin `EngramClient` REST wrapper
- an optional LangChain integration layer
- integration docs for LangChain and LangGraph usage patterns

The goal is to make Engram usable from existing LangChain/LangGraph pipelines without any MCP requirement, while keeping the implementation lightweight and dependency-safe.

## What changed

- added `src/engram/client.py`
  - `EngramClient`
  - `EngramClientError`
  - wraps existing REST endpoints:
    - `query()`
    - `commit()`
    - `batch_commit()`
    - `conflicts()`
  - uses stdlib `urllib`, so no new required HTTP dependency
- added `src/engram/integrations/langchain.py`
  - optional `EngramMemory`
  - imports LangChain only if installed
  - `load_memory_variables()` queries Engram and formats returned facts
  - `save_context()` is a no-op by default to avoid committing raw chat history
  - `commit_fact()` explicitly commits verified facts
- added `src/engram/integrations/__init__.py`
- added `docs/integrations/langchain.md`
  - REST client usage
  - LangChain usage
  - LangGraph node usage pattern
  - documents REST-based integration, not MCP
- updated `README.md`
  - added a small LangChain / LangGraph integration link
- added focused tests:
  - `tests/test_client.py`
  - `tests/test_langchain_adapter.py`

## Why

This makes Engram accessible to existing Python agent pipelines without requiring MCP tooling.

The implementation is intentionally conservative:
- no backend or schema changes
- no required LangChain dependency
- no automatic commit of raw user/LLM chat turns
- no full LangGraph checkpointer/store implementation in v1

This keeps the integration thin and low-risk while still making Engram usable as a REST-backed memory layer in external pipelines.

## Notes

This PR is scoped as a v1:
- thin REST client
- optional LangChain integration
- LangGraph usage documented through client calls inside nodes

The classic `BaseMemory` path is version-dependent. The installed LangChain version in local verification does not expose `BaseMemory`, so one compatibility test is skipped accordingly.

## Verification

Passed locally:

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_client.py tests/test_langchain_adapter.py -q`
- `.venv/bin/pytest tests/ -x --tb=short`

Results:

- `12 passed, 1 skipped` for focused adapter/client tests
- full test suite passed locally

Notes:

- the single skipped test is expected because the installed LangChain version does not expose `BaseMemory`
- adapter coverage still validates client behavior, formatting, and optional dependency behavior
- no live server is required in tests
- existing suite warnings are unchanged and unrelated to this integration work

