### PR TITLE
feat: ticket reference linking in entities and dashboard (#41)

### DIFF
--- a/src/engram/dashboard.py
+++ b/src/engram/dashboard.py
@@ -1417,6 +1417,7 @@ def _render_fact_detail(fact: dict, lineage: list[dict]) -> str:
     lineage_id = fact.get("lineage_id", "")
     query_hits = fact.get("query_hits", 0)
     durability = fact.get("durability", "durable")
+    entities = fact.get("entities") or []
 
     verified = (
         '<span class="badge badge-verified">verified</span>'
@@ -1426,6 +1427,38 @@ def _render_fact_detail(fact: dict, lineage: list[dict]) -> str:
     durability_badge = (
         f'<span class="badge badge-low">{durability}</span>' if durability == "ephemeral" else ""
     )
+
+    ticket_refs = []
+    if isinstance(entities, str):
+        try:
+            import json
+
+            entities = json.loads(entities)
+        except Exception:
+            entities = []
+    if isinstance(entities, list):
+        ticket_refs = [e for e in entities if isinstance(e, dict) and e.get("type") == "ticket_ref"]
+
+    ticket_html = ""
+    if ticket_refs:
+        chips = []
+        for ticket in ticket_refs:
+            ref = _esc(ticket.get("name", ""))
+            chips.append(
+                f'<span style="display:inline-block;padding:0.25rem 0.6rem;'
+                f"background:#eef2ff;color:#3730a3;border:1px solid #c7d2fe;"
+                f'border-radius:999px;font-size:0.8rem;font-weight:500;">'
+                f"{ref}"
+                f"</span>"
+            )
+        ticket_html = f"""
+            <div style="margin-top:1rem;padding-top:1rem;border-top:1px solid #e5e7eb;">
+                <h4 style="font-size:0.9rem;color:#6b7280;margin-bottom:0.5rem;">Linked Tickets</h4>
+                <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+                    {"".join(chips)}
+                </div>
+            </div>
+        """
 
     lineage_html = ""
     if lineage_id:
@@ -1467,6 +1500,8 @@ def _render_fact_detail(fact: dict, lineage: list[dict]) -> str:
                     </div>
                 </div>
             </div>
+
+            {ticket_html}
             
             {lineage_html}
         </div>

--- a/src/engram/entities.py
+++ b/src/engram/entities.py
@@ -63,6 +63,12 @@ _SERVICE_PATTERN = re.compile(
 # Version strings
 _VERSION_PATTERN = re.compile(r"\bv?(?P<value>\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9.]+)?)\b")
 
+# Ticket references: GH-123, LINEAR-456, JIRA-789
+_TICKET_REF_PATTERN = re.compile(
+    r"\b(?P<system>GH|LINEAR|JIRA)-(?P<id>\d+)\b",
+    re.IGNORECASE,
+)
+
 # Technology names (common ones)
 _TECH_NAMES = {
     "postgresql",
@@ -162,6 +168,23 @@ def extract_entities(content: str) -> list[dict[str, Any]]:
         if key not in seen:
             seen.add(key)
             entities.append({"name": name, "type": "version", "value": value})
+
+    # Ticket references
+    for m in _TICKET_REF_PATTERN.finditer(content):
+        system = m.group("system").upper()
+        ticket_id = m.group("id")
+        ref = f"{system}-{ticket_id}"
+        key = f"ticket_ref:{ref}"
+        if key not in seen:
+            seen.add(key)
+            entities.append(
+                {
+                    "name": ref,
+                    "type": "ticket_ref",
+                    "value": ticket_id,
+                    "system": system.lower(),
+                }
+            )
 
     # Limit/cap values: "maximum of 3 projects", "up to 5 users", etc.
     for pattern in (_LIMIT_VALUE_PATTERN, _TRAILING_LIMIT_PATTERN):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import datetime, timezone
 
 import pytest
 
-from engram.dashboard import _esc, _render_index
+from engram.dashboard import _esc, _render_fact_detail, _render_index
 from engram.storage import Storage
 
 
@@ -63,3 +64,36 @@ async def test_dashboard_counts(storage: Storage):
         }
     )
     assert await storage.count_facts() == 1
+
+
+def test_render_fact_detail_shows_ticket_refs():
+    fact = {
+        "id": uuid.uuid4().hex,
+        "content": "Constraint came from GH-123 and LINEAR-456",
+        "scope": "auth",
+        "fact_type": "decision",
+        "confidence": 0.95,
+        "agent_id": "agent-auth",
+        "committed_at": datetime.now(timezone.utc).isoformat(),
+        "provenance": "docs/auth.md",
+        "lineage_id": uuid.uuid4().hex,
+        "query_hits": 3,
+        "durability": "durable",
+        "corroborating_agents": 1,
+        "entities": json.dumps(
+            [
+                {"name": "GH-123", "type": "ticket_ref", "value": "123", "system": "gh"},
+                {
+                    "name": "LINEAR-456",
+                    "type": "ticket_ref",
+                    "value": "456",
+                    "system": "linear",
+                },
+            ]
+        ),
+    }
+
+    html = _render_fact_detail(fact, lineage=[])
+    assert "Linked Tickets" in html
+    assert "GH-123" in html
+    assert "LINEAR-456" in html

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -93,3 +93,19 @@ def test_extracts_user_limit():
     limit_entities = [e for e in entities if e.get("name") == "user_limit"]
     assert len(limit_entities) == 1
     assert limit_entities[0]["value"] == 10
+
+
+def test_extracts_ticket_references():
+    entities = extract_entities(
+        "See GH-123, LINEAR-456, and JIRA-789 before changing the auth gateway."
+    )
+    ticket_entities = [e for e in entities if e["type"] == "ticket_ref"]
+    assert {e["name"] for e in ticket_entities} == {"GH-123", "LINEAR-456", "JIRA-789"}
+    assert {e["system"] for e in ticket_entities} == {"gh", "linear", "jira"}
+
+
+def test_deduplicates_ticket_references():
+    entities = extract_entities("GH-123 was discussed in GH-123 during rollout.")
+    ticket_entities = [e for e in entities if e["type"] == "ticket_ref"]
+    assert len(ticket_entities) == 1
+    assert ticket_entities[0]["name"] == "GH-123"


### PR DESCRIPTION
## Summary
- Extract `GH-123`, `LINEAR-456`, and `JIRA-789` style ticket tokens during entity extraction as structured `ticket_ref` entities (deduped).
- Render a **Linked Tickets** row in the dashboard fact detail when those entities are present.

## Test plan
- `uv run pytest tests/test_entities.py tests/test_dashboard.py`

Closes #41
