### PR TITLE
Add privacy-preserving workspace analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Framework integrations:
 engram install          # Configure your IDE and install the auto-commit hook
 engram verify           # Check that everything is connected
 engram search <query>   # Query workspace memory from the terminal
+engram stats            # Show privacy-preserving workspace analytics
 engram import <path>    # Bulk-ingest Markdown/text docs
 engram tail             # Live stream of commits as they happen
 engram serve --http     # Run the MCP server locally (port 7474)

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -1694,7 +1694,24 @@ def stats(output_json: bool) -> None:
                 click.echo(f"Expiring Soon: {facts.get('expiring_soon', 0)}")
                 click.echo(f"Open Conflicts: {conflicts.get('open', 0)}")
                 click.echo(f"Resolved: {conflicts.get('resolved', 0)}")
+                click.echo(f"Conflict Rate: {(conflicts.get('rate') or 0.0):.2%}")
                 click.echo(f"Total Agents: {agents.get('total', 0)}")
+                most_active = agents.get("most_active") or []
+                if isinstance(most_active, list) and most_active:
+                    click.echo("Most Active Agents:")
+                    for agent in most_active[:5]:
+                        click.echo(
+                            f"  - {agent.get('agent_id')}: {agent.get('total_commits', 0)} commits"
+                        )
+                most_queried = facts.get("most_queried") or []
+                if isinstance(most_queried, list) and most_queried:
+                    click.echo("Most Queried Facts:")
+                    for fact in most_queried[:5]:
+                        click.echo(
+                            f"  - {fact.get('id')} "
+                            f"[{fact.get('scope')}] "
+                            f"{fact.get('query_hits', 0)} queries"
+                        )
     except urllib.error.HTTPError:
         click.echo("=== Workspace Stats ===")
         click.echo(f"Workspace: {ws.engram_id}")

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from engram.schema import POSTGRES_SCHEMA_SQL
-from engram.storage import BaseStorage
+from engram.storage import ANALYTICS_BUCKET_LIMIT, ANALYTICS_TOP_LIMIT, BaseStorage
 
 logger = logging.getLogger("engram")
 
@@ -1110,6 +1110,19 @@ class PostgresStorage(BaseStorage):
             )
             by_durability = {r["durability"]: r["cnt"] for r in dur_rows}
 
+            most_queried_rows = await conn.fetch(
+                """SELECT id, scope, fact_type, query_hits
+                   FROM facts
+                   WHERE valid_until IS NULL
+                     AND workspace_id = $1
+                     AND query_hits > 0
+                   ORDER BY query_hits DESC, committed_at DESC
+                   LIMIT $2""",
+                ws,
+                ANALYTICS_TOP_LIMIT,
+            )
+            most_queried = [_row_to_dict(r) for r in most_queried_rows]
+
             # expiring soon (within 7 days)
             exp_row = await conn.fetchrow(
                 "SELECT COUNT(*) AS cnt FROM facts "
@@ -1126,6 +1139,8 @@ class PostgresStorage(BaseStorage):
                 ws,
             )
             conflict_by_status: dict[str, int] = {r["status"]: r["cnt"] for r in conflict_rows}
+            total_conflicts = sum(conflict_by_status.values())
+            conflict_rate = round(total_conflicts / total_facts, 4) if total_facts else 0.0
 
             # conflicts by tier
             tier_rows = await conn.fetch(
@@ -1143,14 +1158,51 @@ class PostgresStorage(BaseStorage):
             )
             conflict_by_type = {r["conflict_type"]: r["cnt"] for r in type_conflict_rows}
 
+            over_time_rows = await conn.fetch(
+                """SELECT to_char(detected_at, 'YYYY-MM-DD') AS date,
+                          status,
+                          COUNT(*) AS cnt
+                   FROM conflicts
+                   WHERE workspace_id = $1
+                   GROUP BY to_char(detected_at, 'YYYY-MM-DD'), status
+                   ORDER BY date DESC
+                   LIMIT $2""",
+                ws,
+                ANALYTICS_BUCKET_LIMIT * 3,
+            )
+            buckets: dict[str, dict[str, int | str]] = {}
+            for r in over_time_rows:
+                date = r["date"]
+                bucket = buckets.setdefault(
+                    date,
+                    {"date": date, "open": 0, "resolved": 0, "dismissed": 0, "total": 0},
+                )
+                status = (
+                    r["status"] if r["status"] in {"open", "resolved", "dismissed"} else "total"
+                )
+                if status != "total":
+                    bucket[status] = int(bucket[status]) + r["cnt"]
+                bucket["total"] = int(bucket["total"]) + r["cnt"]
+            conflict_over_time = sorted(buckets.values(), key=lambda item: str(item["date"]))
+
             # agents
             agent_rows = await conn.fetch(
-                "SELECT agent_id, total_commits, flagged_commits FROM agents "
+                "SELECT agent_id, total_commits, flagged_commits, last_seen FROM agents "
                 "WHERE workspace_id = $1 ORDER BY total_commits DESC",
                 ws,
             )
             total_agents = len(agent_rows)
-            most_active = agent_rows[0]["agent_id"] if agent_rows else None
+            most_active = [
+                {
+                    "agent_id": r["agent_id"],
+                    "total_commits": r["total_commits"],
+                    "flagged_commits": r["flagged_commits"],
+                    "last_seen": r["last_seen"].isoformat()
+                    if isinstance(r["last_seen"], datetime)
+                    else r["last_seen"],
+                }
+                for r in agent_rows[:ANALYTICS_TOP_LIMIT]
+            ]
             trust_scores = [
                 1.0 - (r["flagged_commits"] / r["total_commits"]) if r["total_commits"] > 0 else 0.8
                 for r in agent_rows
@@ -1174,12 +1226,15 @@ class PostgresStorage(BaseStorage):
                 "by_scope": by_scope,
                 "by_type": by_type,
                 "by_durability": by_durability,
+                "most_queried": most_queried,
             },
             "conflicts": {
                 "open": conflict_by_status.get("open", 0),
                 "resolved": conflict_by_status.get("resolved", 0),
                 "dismissed": conflict_by_status.get("dismissed", 0),
-                "total": sum(conflict_by_status.values()),
+                "total": total_conflicts,
+                "rate": conflict_rate,
+                "over_time": conflict_over_time,
                 "by_tier": conflict_by_tier,
                 "by_type": conflict_by_type,
             },

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -1,6 +1,6 @@
 """Engram MCP Server.
 
-Eight tools total:
+Core tools:
   engram_status           — check setup state; guides agent through onboarding
   engram_init             — founder creates a new workspace (requires ENGRAM_DB_URL)
   engram_join             — teammate joins an existing workspace via Invite Key
@@ -9,6 +9,7 @@ Eight tools total:
   engram_query            — read what the team's agents collectively know
   engram_conflicts        — surface contradictions between facts
   engram_resolve          — settle a disagreement
+  engram_stats            — inspect privacy-preserving workspace analytics
 
 Tool descriptions embed behavioral guidance for the LLM.
 The 'next_prompt' field in onboarding responses tells the agent exactly what to say.
@@ -1360,6 +1361,26 @@ async def engram_timeline(
     if _disc:
         return _disc
     return await engine.get_timeline(scope=scope, limit=limit)
+
+
+@mcp.tool(annotations={"readOnlyHint": True})
+async def engram_stats() -> dict[str, Any]:
+    """Return privacy-preserving aggregate workspace analytics.
+
+    Use this to understand workspace health without exposing memory content:
+    fact counts, safe most-queried fact metadata, conflict rate and daily
+    conflict buckets, active agents, and detection feedback totals.
+
+    Returns: Aggregate statistics only; no fact content is included.
+    """
+    engine = get_engine()
+    from engram.workspace import read_workspace as _rw
+
+    _ws = _rw()
+    _disc = await _check_key_generation(_ws)
+    if _disc:
+        return _disc
+    return await engine.get_stats()
 
 
 @mcp.tool(annotations={"readOnlyHint": True})

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -18,6 +18,8 @@ import aiosqlite
 from engram.schema import POST_MIGRATION_INDEXES, SCHEMA_SQL, SCHEMA_VERSION
 
 DEFAULT_DB_PATH = Path.home() / ".engram" / "knowledge.db"
+ANALYTICS_BUCKET_LIMIT = 30
+ANALYTICS_TOP_LIMIT = 10
 
 
 class BaseStorage(ABC):
@@ -1642,6 +1644,18 @@ class SQLiteStorage(BaseStorage):
         by_durability = {r["durability"]: r["cnt"] for r in await cur.fetchall()}
 
         cur = await self.db.execute(
+            """SELECT id, scope, fact_type, query_hits
+               FROM facts
+               WHERE valid_until IS NULL
+                 AND workspace_id = ?
+                 AND query_hits > 0
+               ORDER BY query_hits DESC, committed_at DESC
+               LIMIT ?""",
+            (ws, ANALYTICS_TOP_LIMIT),
+        )
+        most_queried = [dict(r) for r in await cur.fetchall()]
+
+        cur = await self.db.execute(
             "SELECT COUNT(*) as cnt FROM facts "
             "WHERE ttl_days IS NOT NULL AND valid_until IS NULL AND workspace_id = ? "
             "AND datetime(valid_from, '+' || ttl_days || ' days') < datetime('now', '+7 days')",
@@ -1658,6 +1672,8 @@ class SQLiteStorage(BaseStorage):
         conflict_by_status: dict[str, int] = {}
         for r in await cur.fetchall():
             conflict_by_status[r["status"]] = r["cnt"]
+        total_conflicts = sum(conflict_by_status.values())
+        conflict_rate = round(total_conflicts / total_facts, 4) if total_facts else 0.0
 
         cur = await self.db.execute(
             "SELECT detection_tier, COUNT(*) as cnt FROM conflicts "
@@ -1673,15 +1689,47 @@ class SQLiteStorage(BaseStorage):
         )
         conflict_by_type = {r["conflict_type"]: r["cnt"] for r in await cur.fetchall()}
 
+        cur = await self.db.execute(
+            """SELECT substr(detected_at, 1, 10) AS date,
+                      status,
+                      COUNT(*) AS cnt
+               FROM conflicts
+               WHERE workspace_id = ?
+               GROUP BY date, status
+               ORDER BY date DESC
+               LIMIT ?""",
+            (ws, ANALYTICS_BUCKET_LIMIT * 3),
+        )
+        buckets: dict[str, dict[str, int | str]] = {}
+        for r in await cur.fetchall():
+            date = r["date"]
+            bucket = buckets.setdefault(
+                date,
+                {"date": date, "open": 0, "resolved": 0, "dismissed": 0, "total": 0},
+            )
+            status = r["status"] if r["status"] in {"open", "resolved", "dismissed"} else "total"
+            if status != "total":
+                bucket[status] = int(bucket[status]) + r["cnt"]
+            bucket["total"] = int(bucket["total"]) + r["cnt"]
+        conflict_over_time = sorted(buckets.values(), key=lambda item: str(item["date"]))
+
         # ── agents ──────────────────────────────────────────────────
         cur = await self.db.execute(
-            "SELECT agent_id, total_commits, flagged_commits FROM agents "
+            "SELECT agent_id, total_commits, flagged_commits, last_seen FROM agents "
             "WHERE workspace_id = ? ORDER BY total_commits DESC",
             (ws,),
         )
         agent_rows = await cur.fetchall()
         total_agents = len(agent_rows)
-        most_active = agent_rows[0]["agent_id"] if agent_rows else None
+        most_active = [
+            {
+                "agent_id": r["agent_id"],
+                "total_commits": r["total_commits"],
+                "flagged_commits": r["flagged_commits"],
+                "last_seen": r["last_seen"],
+            }
+            for r in agent_rows[:ANALYTICS_TOP_LIMIT]
+        ]
         trust_scores = [
             1.0 - (r["flagged_commits"] / r["total_commits"]) if r["total_commits"] > 0 else 0.8
             for r in agent_rows
@@ -1705,12 +1753,15 @@ class SQLiteStorage(BaseStorage):
                 "by_scope": by_scope,
                 "by_type": by_type,
                 "by_durability": by_durability,
+                "most_queried": most_queried,
             },
             "conflicts": {
                 "open": conflict_by_status.get("open", 0),
                 "resolved": conflict_by_status.get("resolved", 0),
                 "dismissed": conflict_by_status.get("dismissed", 0),
-                "total": sum(conflict_by_status.values()),
+                "total": total_conflicts,
+                "rate": conflict_rate,
+                "over_time": conflict_over_time,
                 "by_tier": conflict_by_tier,
                 "by_type": conflict_by_type,
             },

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -455,6 +455,71 @@ async def test_get_workspace_stats_conflict_counts(storage: Storage):
     assert stats["conflicts"]["total"] >= 1
 
 
+@pytest.mark.asyncio
+async def test_get_workspace_stats_most_queried_is_privacy_preserving(storage: Storage):
+    f1 = _fact(content="secret implementation detail", scope="auth")
+    f2 = _fact(content="another private fact", scope="billing")
+    await storage.insert_fact(f1)
+    await storage.insert_fact(f2)
+    await storage.db.execute("UPDATE facts SET query_hits = ? WHERE id = ?", (5, f1["id"]))
+    await storage.db.execute("UPDATE facts SET query_hits = ? WHERE id = ?", (2, f2["id"]))
+    await storage.db.commit()
+
+    stats = await storage.get_workspace_stats()
+    most_queried = stats["facts"]["most_queried"]
+
+    assert [fact["id"] for fact in most_queried[:2]] == [f1["id"], f2["id"]]
+    assert most_queried[0]["query_hits"] == 5
+    assert most_queried[0]["scope"] == "auth"
+    assert "content" not in most_queried[0]
+    assert "engineer" not in most_queried[0]
+    assert "provenance" not in most_queried[0]
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_stats_most_active_agents(storage: Storage):
+    await storage.upsert_agent("agent-low")
+    await storage.upsert_agent("agent-high")
+    await storage.increment_agent_commits("agent-low")
+    await storage.increment_agent_commits("agent-high")
+    await storage.increment_agent_commits("agent-high")
+    await storage.increment_agent_flagged("agent-high")
+
+    stats = await storage.get_workspace_stats()
+    most_active = stats["agents"]["most_active"]
+
+    assert most_active[0]["agent_id"] == "agent-high"
+    assert most_active[0]["total_commits"] == 2
+    assert most_active[0]["flagged_commits"] == 1
+    assert "last_seen" in most_active[0]
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_stats_conflict_rate_and_over_time(storage: Storage):
+    f1 = _fact()
+    f2 = _fact()
+    f3 = _fact()
+    for f in (f1, f2, f3):
+        await storage.insert_fact(f)
+
+    open_conflict = _conflict(f1["id"], f2["id"], status="open")
+    open_conflict["detected_at"] = "2026-04-01T10:00:00+00:00"
+    resolved_conflict = _conflict(f2["id"], f3["id"], status="resolved")
+    resolved_conflict["detected_at"] = "2026-04-01T12:00:00+00:00"
+    dismissed_conflict = _conflict(f1["id"], f3["id"], status="dismissed")
+    dismissed_conflict["detected_at"] = "2026-04-02T09:00:00+00:00"
+    for conflict in (open_conflict, resolved_conflict, dismissed_conflict):
+        await storage.insert_conflict(conflict)
+
+    stats = await storage.get_workspace_stats()
+
+    assert stats["conflicts"]["rate"] == 1.0
+    assert stats["conflicts"]["over_time"] == [
+        {"date": "2026-04-01", "open": 1, "resolved": 1, "dismissed": 0, "total": 2},
+        {"date": "2026-04-02", "open": 0, "resolved": 0, "dismissed": 1, "total": 1},
+    ]
+
+
 # ── close_validity_window ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a focused v1 privacy-preserving workspace analytics enhancement to the existing `engram stats`, `/api/stats`, and MCP stats surface.

This keeps analytics local to the workspace and returns aggregate metadata only. It does not send telemetry to Engram servers and does not expose fact content.

## What changed

- extended workspace stats in:
  - `src/engram/storage.py`
  - `src/engram/postgres_storage.py`
- added privacy-preserving fact analytics:
  - `facts.most_queried`
  - includes `id`, `scope`, `fact_type`, and `query_hits`
  - intentionally excludes fact `content`, `engineer`, and `provenance`
- added conflict analytics:
  - `conflicts.rate`
  - `conflicts.over_time` daily buckets by status
- expanded agent analytics:
  - `agents.most_active` now returns top active agents with commit and flagged counts
- added read-only MCP tool:
  - `engram_stats`
- updated `engram stats` CLI output to show:
  - conflict rate
  - top active agents
  - most queried facts
- updated `README.md` CLI reference
- added focused storage coverage in `tests/test_storage.py`

## Why

Teams need operational visibility into workspace health without exposing memory content or sending telemetry outside their environment.

This helps answer:
- how many facts are in the workspace
- which agents are most active
- what the conflict rate is
- how conflicts are trending over time
- which facts are queried most often

## Privacy notes

This PR only returns aggregate counts and safe metadata.

`facts.most_queried` intentionally does not include fact content, engineer names, provenance, or other sensitive memory details.

## Verification

Passed locally:

- `git diff --check`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_storage.py tests/test_rest.py tests/test_tool_versioning.py -q` — 150 passed
- `.venv/bin/pytest tests/ -x --tb=short` — 550 passed, 1 skipped, 18 warnings

The 18 warnings are existing Python 3.12 `aiosqlite` date-adapter warnings from `tests/test_metering.py`, unrelated to this PR.

