### PR TITLE
Expose conflict detection stats in engram status

### DIFF
--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -263,6 +263,35 @@ async def _check_key_generation(ws: Any) -> dict[str, Any] | None:
 # ── engram_status ─────────────────────────────────────────────────────
 
 
+async def _conflict_detection_summary() -> dict[str, Any]:
+    """Return conflict detection counters for status observability."""
+    fallback: dict[str, Any] = {
+        "status": "unavailable",
+        "open": 0,
+        "resolved": 0,
+        "dismissed": 0,
+        "total": 0,
+        "by_tier": {},
+        "by_type": {},
+    }
+    try:
+        stats = await get_engine().get_stats()
+    except Exception as exc:
+        logger.debug("Conflict detection stats unavailable: %s", exc)
+        return fallback
+
+    conflicts = stats.get("conflicts") or {}
+    return {
+        "status": "available",
+        "open": conflicts.get("open", 0),
+        "resolved": conflicts.get("resolved", 0),
+        "dismissed": conflicts.get("dismissed", 0),
+        "total": conflicts.get("total", 0),
+        "by_tier": conflicts.get("by_tier", {}),
+        "by_type": conflicts.get("by_type", {}),
+    }
+
+
 @mcp.tool(annotations={"readOnlyHint": False, "destructiveHint": False})
 async def engram_status() -> dict[str, Any]:
     """Check whether Engram is configured and get the next setup step.
@@ -346,6 +375,7 @@ async def engram_status() -> dict[str, Any]:
             "engram_id": ws.engram_id,
             "schema": ws.schema,
             "anonymous_mode": ws.anonymous_mode,
+            "conflict_detection": await _conflict_detection_summary(),
             "next_prompt": (
                 "Engram is connected and ready.\n\n"
                 "User messages are captured automatically by IDE-level hooks. "
@@ -363,6 +393,7 @@ async def engram_status() -> dict[str, Any]:
             "status": "ready",
             "mode": "local",
             "engram_id": "local",
+            "conflict_detection": await _conflict_detection_summary(),
             "next_prompt": (
                 "Engram is connected and ready (local mode).\n\n"
                 "User messages are captured automatically by IDE-level hooks. "

--- a/tests/test_tool_versioning.py
+++ b/tests/test_tool_versioning.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from engram.server import engram_resolve, engram_status
@@ -13,6 +15,18 @@ async def test_engram_status_exposes_tool_surface_metadata():
 
 
 class DummyEngine:
+    async def get_stats(self):
+        return {
+            "conflicts": {
+                "open": 2,
+                "resolved": 3,
+                "dismissed": 1,
+                "total": 6,
+                "by_tier": {"tier1_nli": 4, "tier2_numeric": 2},
+                "by_type": {"genuine": 5, "evolution": 1},
+            }
+        }
+
     async def resolve(self, conflict_id, resolution_type, resolution, winning_claim_id=None):
         return {
             "resolved": True,
@@ -20,6 +34,11 @@ class DummyEngine:
             "resolution_type": resolution_type,
             "winning_claim_id": winning_claim_id,
         }
+
+
+class BrokenStatsEngine:
+    async def get_stats(self):
+        raise RuntimeError("stats unavailable")
 
 
 @pytest.mark.asyncio
@@ -57,3 +76,72 @@ async def test_engram_resolve_current_param_has_no_warning(monkeypatch):
     assert result["resolved"] is True
     assert result["winning_claim_id"] == "claim-123"
     assert "deprecation_warnings" not in result
+
+
+@pytest.mark.asyncio
+async def test_engram_status_exposes_conflict_detection_summary(monkeypatch, tmp_path):
+    from engram import server, workspace
+
+    marker = tmp_path / "workspace.json"
+    marker.write_text("{}")
+    ws = SimpleNamespace(
+        db_url=None,
+        engram_id="local",
+        schema="engram",
+        anonymous_mode=False,
+        key_generation=0,
+    )
+
+    monkeypatch.setattr(server, "_engine", DummyEngine())
+    monkeypatch.setattr(server, "_storage", None)
+    monkeypatch.setattr(server, "_read_engram_env", lambda: None)
+    monkeypatch.setattr(workspace, "read_workspace", lambda: ws)
+    monkeypatch.setattr(workspace, "WORKSPACE_PATH", marker)
+
+    result = await engram_status()
+
+    assert result["status"] == "ready"
+    assert result["conflict_detection"] == {
+        "status": "available",
+        "open": 2,
+        "resolved": 3,
+        "dismissed": 1,
+        "total": 6,
+        "by_tier": {"tier1_nli": 4, "tier2_numeric": 2},
+        "by_type": {"genuine": 5, "evolution": 1},
+    }
+    assert "tool_surface_version" in result
+
+
+@pytest.mark.asyncio
+async def test_engram_status_keeps_ready_when_conflict_stats_unavailable(monkeypatch, tmp_path):
+    from engram import server, workspace
+
+    marker = tmp_path / "workspace.json"
+    marker.write_text("{}")
+    ws = SimpleNamespace(
+        db_url=None,
+        engram_id="local",
+        schema="engram",
+        anonymous_mode=False,
+        key_generation=0,
+    )
+
+    monkeypatch.setattr(server, "_engine", BrokenStatsEngine())
+    monkeypatch.setattr(server, "_storage", None)
+    monkeypatch.setattr(server, "_read_engram_env", lambda: None)
+    monkeypatch.setattr(workspace, "read_workspace", lambda: ws)
+    monkeypatch.setattr(workspace, "WORKSPACE_PATH", marker)
+
+    result = await engram_status()
+
+    assert result["status"] == "ready"
+    assert result["conflict_detection"] == {
+        "status": "unavailable",
+        "open": 0,
+        "resolved": 0,
+        "dismissed": 0,
+        "total": 0,
+        "by_tier": {},
+        "by_type": {},
+    }


### PR DESCRIPTION
## Summary

Completes the remaining conflict-detection observability gap from #247 by exposing conflict detection stats in `engram_status()`.

Most of the pipeline fixes described in the issue are already present in `main`, including non-blocking document import, accurate queue overflow reporting, conflict type classification, evolution auto-resolution, and `conflict.detected` events. This PR adds the missing status visibility layer.

## What changed

- added a safe conflict detection summary helper in `src/engram/server.py`
- added `conflict_detection` to ready `engram_status()` responses
- included aggregate conflict observability fields:
  - `open`
  - `resolved`
  - `dismissed`
  - `total`
  - `by_tier`
  - `by_type`
- added fallback behavior so `engram_status()` still returns ready if stats are temporarily unavailable
- added tests in `tests/test_tool_versioning.py`

## Why

Operators and agents need to know whether conflict detection is producing results and which detection tiers are active.

This makes the detection pipeline observable from the first required MCP call, without changing detection behavior or adding schema changes.

## Scope notes

This PR does not reimplement the other pipeline fixes because they already exist in `main`:

- `import_documents()` uses `asyncio.to_thread()`
- detection queue overflow returns `conflict_check_queued: false`
- same-agent updates classify as `evolution` and auto-resolve
- cross-agent contradictions classify as `genuine`
- `conflict.detected` webhook events are fired

## Verification

Passed locally:

- `git diff --check`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_tool_versioning.py -q` — 5 passed
- `.venv/bin/pytest tests/ -x --tb=short` — 555 passed, 1 skipped, 18 warnings

The 18 warnings are existing Python 3.12 `aiosqlite` date-adapter warnings from `tests/test_metering.py`, unrelated to this PR.

