### PR TITLE
Add OpenAI Agents SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Agents without MCP support connect via the REST API using the credentials in `.e
 Framework integrations:
 
 - [LangChain / LangGraph](./docs/integrations/langchain.md)
+- [OpenAI Agents SDK](./docs/integrations/openai-agents.md)
 
 ---
 

--- a/docs/integrations/openai-agents.md
+++ b/docs/integrations/openai-agents.md
@@ -1,0 +1,70 @@
+# OpenAI Agents SDK Integration
+
+Engram can be used from OpenAI Agents SDK workflows through function tools backed by
+the Engram HTTP API. This does not require MCP.
+
+Start a local Engram HTTP server:
+
+```bash
+engram serve --http
+```
+
+Install the OpenAI Agents SDK in the application that will run the agent:
+
+```bash
+pip install openai-agents
+```
+
+## Usage
+
+```python
+from agents import Agent, Runner
+
+from engram.integrations.openai_agents import create_engram_tools
+
+
+tools = create_engram_tools(
+    base_url="http://127.0.0.1:7474",
+    api_key="ek_live_YOUR_INVITE_KEY",
+    default_scope="auth",
+)
+
+agent = Agent(
+    name="Engram-aware agent",
+    instructions=(
+        "Query Engram before making architecture decisions. "
+        "Commit only verified discoveries, decisions, and corrections."
+    ),
+    tools=tools,
+)
+
+Runner.run_sync(agent, "What do we know about auth?")
+```
+
+The integration exposes three tools:
+
+| Tool | Purpose |
+|---|---|
+| `engram_query` | Read verified workspace facts relevant to a topic |
+| `engram_commit` | Commit a verified fact to Engram |
+| `engram_conflicts` | Review open or resolved conflicts before important decisions |
+
+## Memory Model
+
+The OpenAI Agents SDK `Session` memory stores conversation turns. Engram stores
+verified shared workspace facts. Keep those responsibilities separate:
+
+- use SDK sessions for short-term conversation history
+- use Engram for durable team knowledge that should survive across agents and sessions
+- do not commit raw chat transcripts to Engram
+
+## Without an Invite Key
+
+For local development without auth:
+
+```python
+tools = create_engram_tools(base_url="http://127.0.0.1:7474")
+```
+
+For team mode, pass the invite key as `api_key`; it is sent as a Bearer token to
+Engram's REST API.

--- a/src/engram/integrations/openai_agents.py
+++ b/src/engram/integrations/openai_agents.py
@@ -1,0 +1,95 @@
+"""OpenAI Agents SDK integration for Engram."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from engram.client import EngramClient
+
+try:
+    from agents import function_tool as _function_tool
+except ImportError as exc:  # pragma: no cover - exercised through helper tests
+    _function_tool = None
+    _OPENAI_AGENTS_IMPORT_ERROR = exc
+else:
+    _OPENAI_AGENTS_IMPORT_ERROR = None
+
+
+ToolDecorator = Callable[[Callable[..., Any]], Any]
+
+
+def _missing_openai_agents_error() -> ImportError:
+    return ImportError(
+        "OpenAI Agents SDK support is optional. Install it to use "
+        "engram.integrations.openai_agents. Example: pip install openai-agents"
+    )
+
+
+def create_engram_tools(
+    *,
+    client: EngramClient | None = None,
+    base_url: str = "http://127.0.0.1:7474",
+    api_key: str | None = None,
+    timeout: float = 30.0,
+    default_scope: str | None = None,
+    tool_decorator: ToolDecorator | None = None,
+) -> list[Any]:
+    """Create OpenAI Agents SDK function tools backed by Engram.
+
+    The OpenAI Agents SDK remains optional. Pass ``tool_decorator`` in tests or
+    advanced integrations to avoid importing the SDK directly.
+    """
+    decorator = tool_decorator or _function_tool
+    if decorator is None:
+        raise _missing_openai_agents_error() from _OPENAI_AGENTS_IMPORT_ERROR
+
+    resolved_client = client or EngramClient(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+    )
+
+    def engram_query(
+        topic: str,
+        scope: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Query verified Engram workspace facts relevant to a topic."""
+        return resolved_client.query(
+            topic,
+            scope=scope or default_scope,
+            limit=limit,
+        )
+
+    def engram_commit(
+        content: str,
+        scope: str | None = None,
+        confidence: float = 0.8,
+        fact_type: str = "observation",
+        provenance: str | None = None,
+    ) -> dict[str, Any]:
+        """Commit a verified fact to Engram; do not store raw chat history."""
+        return resolved_client.commit(
+            content,
+            scope=scope or default_scope or "general",
+            confidence=confidence,
+            fact_type=fact_type,
+            provenance=provenance,
+        )
+
+    def engram_conflicts(
+        scope: str | None = None,
+        status: str = "open",
+    ) -> list[dict[str, Any]]:
+        """List Engram conflicts for review before important decisions."""
+        return resolved_client.conflicts(
+            scope=scope or default_scope,
+            status=status,
+        )
+
+    return [
+        decorator(engram_query),
+        decorator(engram_commit),
+        decorator(engram_conflicts),
+    ]

--- a/tests/test_openai_agents_integration.py
+++ b/tests/test_openai_agents_integration.py
@@ -1,0 +1,147 @@
+"""Tests for the optional OpenAI Agents SDK integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from engram.integrations import openai_agents
+
+
+class FakeClient:
+    def __init__(self):
+        self.queries: list[dict[str, Any]] = []
+        self.commits: list[dict[str, Any]] = []
+        self.conflict_requests: list[dict[str, Any]] = []
+
+    def query(self, topic, *, scope=None, limit=10):
+        self.queries.append({"topic": topic, "scope": scope, "limit": limit})
+        return [{"content": "Auth uses JWT", "scope": scope or "general"}]
+
+    def commit(self, content, **kwargs):
+        self.commits.append({"content": content, **kwargs})
+        return {"fact_id": "fact-1", "duplicate": False}
+
+    def conflicts(self, *, scope=None, status="open"):
+        self.conflict_requests.append({"scope": scope, "status": status})
+        return [{"id": "conflict-1", "status": status}]
+
+
+def identity_tool(func):
+    func.is_test_tool = True
+    return func
+
+
+def _tools_by_name(client=None, **kwargs):
+    tools = openai_agents.create_engram_tools(
+        client=client or FakeClient(),
+        tool_decorator=identity_tool,
+        **kwargs,
+    )
+    return {tool.__name__: tool for tool in tools}
+
+
+def test_create_engram_tools_returns_expected_tool_names():
+    tools = _tools_by_name()
+
+    assert set(tools) == {"engram_query", "engram_commit", "engram_conflicts"}
+    assert all(tool.is_test_tool for tool in tools.values())
+
+
+def test_query_tool_calls_client_with_default_scope():
+    client = FakeClient()
+    tools = _tools_by_name(client=client, default_scope="auth")
+
+    result = tools["engram_query"]("How does auth work?", limit=3)
+
+    assert result == [{"content": "Auth uses JWT", "scope": "auth"}]
+    assert client.queries == [{"topic": "How does auth work?", "scope": "auth", "limit": 3}]
+
+
+def test_query_tool_explicit_scope_overrides_default_scope():
+    client = FakeClient()
+    tools = _tools_by_name(client=client, default_scope="auth")
+
+    tools["engram_query"]("How does billing work?", scope="billing")
+
+    assert client.queries == [{"topic": "How does billing work?", "scope": "billing", "limit": 10}]
+
+
+def test_commit_tool_calls_client_with_verified_fact_payload():
+    client = FakeClient()
+    tools = _tools_by_name(client=client, default_scope="auth")
+
+    result = tools["engram_commit"](
+        "Auth validates JWTs on every request",
+        confidence=0.9,
+        fact_type="decision",
+        provenance="docs/auth.md",
+    )
+
+    assert result == {"fact_id": "fact-1", "duplicate": False}
+    assert client.commits == [
+        {
+            "content": "Auth validates JWTs on every request",
+            "scope": "auth",
+            "confidence": 0.9,
+            "fact_type": "decision",
+            "provenance": "docs/auth.md",
+        }
+    ]
+
+
+def test_commit_tool_explicit_scope_overrides_default_scope():
+    client = FakeClient()
+    tools = _tools_by_name(client=client, default_scope="auth")
+
+    tools["engram_commit"]("Billing retries webhooks.", scope="billing")
+
+    assert client.commits[0]["scope"] == "billing"
+
+
+def test_conflicts_tool_calls_client():
+    client = FakeClient()
+    tools = _tools_by_name(client=client, default_scope="auth")
+
+    result = tools["engram_conflicts"](status="resolved")
+
+    assert result == [{"id": "conflict-1", "status": "resolved"}]
+    assert client.conflict_requests == [{"scope": "auth", "status": "resolved"}]
+
+
+def test_factory_builds_client_from_connection_options(monkeypatch):
+    created: dict[str, Any] = {}
+
+    class RecordingClient(FakeClient):
+        def __init__(self, base_url, *, api_key=None, timeout=30.0):
+            super().__init__()
+            created["base_url"] = base_url
+            created["api_key"] = api_key
+            created["timeout"] = timeout
+
+    monkeypatch.setattr(openai_agents, "EngramClient", RecordingClient)
+
+    tools = openai_agents.create_engram_tools(
+        base_url="http://engram.local",
+        api_key="ek_test",
+        timeout=3.0,
+        tool_decorator=identity_tool,
+    )
+
+    query_tool = {tool.__name__: tool for tool in tools}["engram_query"]
+    query_tool("anything")
+
+    assert created == {
+        "base_url": "http://engram.local",
+        "api_key": "ek_test",
+        "timeout": 3.0,
+    }
+
+
+def test_missing_openai_agents_sdk_error_is_actionable(monkeypatch):
+    monkeypatch.setattr(openai_agents, "_function_tool", None)
+    monkeypatch.setattr(openai_agents, "_OPENAI_AGENTS_IMPORT_ERROR", ImportError("missing"))
+
+    with pytest.raises(ImportError, match="pip install openai-agents"):
+        openai_agents.create_engram_tools(client=FakeClient())


### PR DESCRIPTION
## Summary

Adds a focused v1 OpenAI Agents SDK integration for Engram.

This exposes Engram through optional SDK-compatible function tools backed by the existing `EngramClient`, without requiring MCP or changing Engram backend behavior.

The integration provides tools for:

- querying verified workspace memory
- committing verified facts
- reviewing conflicts

## What changed

- added `src/engram/integrations/openai_agents.py`
  - exposes `create_engram_tools(...)`
  - wraps the existing `EngramClient`
  - keeps OpenAI Agents SDK optional
  - supports injected clients for tests and custom usage
- added `docs/integrations/openai-agents.md`
  - setup instructions
  - usage example with `Agent`, `Runner`, and `create_engram_tools`
  - clarification that OpenAI `Session` memory stores conversation history while Engram stores verified shared workspace facts
- updated `README.md`
  - adds OpenAI Agents SDK under framework integrations
- added `tests/test_openai_agents_integration.py`

## Why

OpenAI Agents SDK users should be able to use Engram as durable shared workspace memory without adopting MCP.

This keeps the integration low-risk by using Engram's existing REST client rather than introducing backend, schema, or server changes.

## Scope notes

This PR intentionally avoids:

- making OpenAI Agents SDK a required dependency
- replacing OpenAI SDK `Session` memory
- storing raw chat history in Engram
- changing Engram REST, MCP, engine, or storage behavior
- modifying `src/engram/integrations/__init__.py`

## Verification

Passed locally:

- `git diff --check`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest tests/test_openai_agents_integration.py -q` — 8 passed
- `.venv/bin/pytest tests/test_client.py tests/test_langchain_adapter.py tests/test_openai_agents_integration.py -q` — 20 passed, 1 skipped
- `.venv/bin/pytest tests/ -x --tb=short` — 563 passed, 1 skipped, 18 warnings

The 18 warnings are existing Python 3.12 `aiosqlite` date-adapter warnings from `tests/test_metering.py`, unrelated to this PR.


