### PR TITLE
docs: add workspace federation design (issue #12)

### DIFF
--- a/docs/AGENT_IDENTITY_TRUST.md
+++ b/docs/AGENT_IDENTITY_TRUST.md
@@ -1,0 +1,125 @@
+# Agent Identity and Trust Levels (Issue #33)
+
+## Overview
+
+Engram tracks agent identity and assigns trust scores based on behavior, enabling smarter conflict resolution and fact validation.
+
+## Agent Identity
+
+### Identity Fields
+
+Each agent has:
+```python
+Agent {
+    id: str                    # Unique identifier
+    name: str                 # Display name
+    first_seen: datetime     # First appearance
+    commit_count: int         # Total commits
+    conflict_count: int       # Conflicts resolved
+    trust_score: float       # 0.0 - 1.0
+    is_anonymous: bool       # Anonymous mode
+}
+```
+
+### Identity Storage
+
+```sql
+CREATE TABLE agents (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    first_seen TIMESTAMP DEFAULT NOW(),
+    commit_count INT DEFAULT 0,
+    conflict_count INT DEFAULT 0,
+    trust_score FLOAT DEFAULT 0.5,
+    is_anonymous BOOLEAN DEFAULT FALSE,
+    workspace_id TEXT REFERENCES workspaces(id)
+);
+```
+
+## Trust Score Calculation
+
+### Factors (weight)
+
+| Factor | Weight | Description |
+|--------|--------|------------|
+| Historical accuracy | 0.30 | Past facts proven correct |
+| Commit count | 0.20 | Number of commits |
+| Conflict resolution | 0.25 | Conflicts resolved positively |
+| Recency | 0.15 | Recent activity |
+| Corroboration | 0.10 | Multiple agents agree |
+
+### Formula
+
+```
+trust_score = 
+    0.30 * accuracy 
+  + 0.20 * (commits / max_commits)
+  + 0.25 * (resolved / conflicts)
+  + 0.15 * recency_factor
+  + 0.10 * corroboration_count
+```
+
+Where:
+- `accuracy` = correct_facts / total_facts
+- `recency_factor` = time_since_last_commit / max_window
+- Values normalized to 0.0-1.0
+
+## Trust Levels
+
+| Level | Score Range | Behavior |
+|-------|-----------|---------|
+| **High** | 0.8-1.0 | Auto-approve commits |
+| **Medium** | 0.5-0.79 | Normal processing |
+| **Low** | 0.2-0.49 | Require review |
+| **Untrusted** | 0.0-0.19 | Quarantine facts |
+
+## Usage Examples
+
+### Query Agent Trust
+
+```python
+# Via MCP tool
+engram_agent_info(agent_id="agent-123")
+# Returns: {trust_score: 0.85, level: "high", commit_count: 50}
+```
+
+### Filter by Trust
+
+```python
+# Only accept high-trust facts
+facts = query(trust_threshold=0.8)
+
+# Exclude untrusted
+facts = exclude(trust_level="untrusted")
+```
+
+## Implementation
+
+### Database Migration
+
+```sql
+ALTER TABLE agents ADD COLUMN trust_score FLOAT DEFAULT 0.5;
+ALTER TABLE agents ADD COLUMN trust_updated_at TIMESTAMP;
+ALTER TABLE facts ADD COLUMN agent_trust_score FLOAT;
+```
+
+### API Endpoints
+
+```
+GET /api/agents/<id>/trust     # Get agent trust
+POST /api/agents/<id>/trust   # Update trust (system only)
+GET /api/agents/trust        # List all with trust
+```
+
+## Security
+
+- Trust updates are **system-only** (not exposed to agents)
+- Anonymous agents get random IDs but track history
+- Trust scores never decrease abruptly (smoothing)
+
+## Migration Path
+
+1. Add columns to agents table
+2. Compute initial scores from history
+3. Update scores on each commit/resolution
+4. Add trust filtering to queries

--- a/docs/DEMO_VIDEO.md
+++ b/docs/DEMO_VIDEO.md
@@ -1,0 +1,116 @@
+# Engram CLI Walkthrough - Demo Video Script
+
+This guide provides a complete walkthrough for creating an Engram demo video.
+
+## Pre-Recording Setup
+
+### 1. Clean Environment
+```bash
+# Start fresh
+rm -rf ~/.engram/workspace.db
+export ENGRAM_INVITE_KEY="ek_live_xxx"
+```
+
+### 2. Open Two Terminals
+- Terminal 1: `engram serve --http` (server)
+- Terminal 2: CLI commands
+
+## Script Outline (5-7 minutes)
+
+### Opening (30s)
+- "Hi! I'm going to show you Engram - a multi-agent memory platform"
+- Show the website: engram-memory.com
+- Quick pitch: "Engram catches when your AI agents contradict each other"
+
+### Setup (1 min)
+```bash
+# Quick setup
+engram init
+engram status
+```
+
+### Core Workflow (3 min)
+
+#### 1. Making a Discovery (30s)
+```bash
+# Agent finds something
+engram commit --content "API timeout is 30 seconds" --scope api-config
+```
+
+#### 2. Another Agent Contradicts (30s)
+```bash
+# Different agent commits contradiction
+engram commit --content "API timeout is 60 seconds" --scope api-config
+```
+
+#### 3. Conflict Detection (1 min)
+```bash
+# Check conflicts
+engram conflicts
+
+# Open dashboard
+engram serve --http
+# Go to localhost:7474/dashboard/conflicts
+```
+
+#### 4. Resolution (30s)
+- Show dashboard
+- Click "Approve" on one fact
+- Show both facts update
+
+### Advanced Features (2 min)
+
+#### Query
+```bash
+engram query timeout
+```
+
+#### Stats
+```bash
+engram stats
+```
+
+#### Webhooks (optional)
+```bash
+engram webhook --url https://your-app.com/hook --events conflict.detected
+```
+
+### Closing (30s)
+- Show website
+- "Get started at engram-memory.com"
+- Mention GitHub stars
+
+## Tips for Recording
+
+### Do
+- ✅ Practice commands before recording
+- ✅ Use a clean, minimal terminal theme
+- ✅ Show the dashboard conflicts tab
+- ✅ Highlight the "aha!" moment of conflict detection
+
+### Don't
+- ❌ Don't show auth setup in detail
+- ❌ Don't use real API keys
+- ❌ Don't go over 7 minutes
+- ❌ Don't show errors/debug output
+
+## Post-Production
+
+### Editing
+- Cut: Setup overhead
+- Add: Music overlay
+- Add: Captions for key commands
+
+### Thumbnail
+- Show "Engram" logo
+- "Conflict Detection" as subtitle
+
+## Export Settings
+- 1080p minimum
+- H.264 codec
+- 30fps
+- No subtitle track (add in YouTube)
+
+---
+
+*For internal use - adjust for specific video requirements*

--- a/docs/STORAGE_BACKEND_INTERFACE.md
+++ b/docs/STORAGE_BACKEND_INTERFACE.md
@@ -1,0 +1,208 @@
+# Pluggable Storage Backend Interface (Issue #13)
+
+## Overview
+
+Engram supports multiple storage backends, allowing teams to choose the best storage solution for their needs.
+
+## Supported Backends
+
+| Backend | Use Case | Status |
+|---------|---------|-------|
+| **SQLite** | Local development | ✅ Default |
+| **PostgreSQL** | Production | ✅ Supported |
+| **MySQL** | Alternative SQL | 🔜 Planned |
+| **DynamoDB** | AWS Serverless | 🔜 Planned |
+| **Redis** | Caching layer | 🔜 Planned |
+
+## Interface Definition
+
+```python
+from abc import ABC, abstractmethod
+from typing import Any
+
+class StorageBackend(ABC):
+    """Abstract storage backend for Engram."""
+    
+    workspace_id: str
+    
+    async def connect(self) -> None:
+        """Initialize connection."""
+        pass
+    
+    async def close(self) -> None:
+        """Close connection."""
+        pass
+    
+    # ── Fact Operations ─────────────────────────────────────
+    
+    @abstractmethod
+    async def insert_fact(self, fact: dict[str, Any]) -> str:
+        """Insert a fact. Returns fact_id."""
+        ...
+    
+    @abstractmethod
+    async def get_fact(self, fact_id: str) -> dict | None:
+        """Get fact by ID."""
+        ...
+    
+    @abstractmethod
+    async def query_facts(
+        self,
+        topic: str | None = None,
+        scope: str | None = None,
+        agent_id: str | None = None,
+        durability: str | None = None,
+        after: str | None = None,
+        before: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Query facts with filters."""
+        ...
+    
+    @abstractmethod
+    async def update_fact(self, fact_id: str, updates: dict) -> bool:
+        """Update fact. Returns success."""
+        ...
+    
+    @abstractmethod
+    async def delete_fact(self, fact_id: str) -> bool:
+        """Soft delete fact. Returns success."""
+        ...
+    
+    # ── Conflict Operations ─────────────────────────────────
+    
+    @abstractmethod
+    async def insert_conflict(self, conflict: dict) -> None:
+        """Insert conflict."""
+        ...
+    
+    @abstractmethod
+    async def get_conflicts(
+        self,
+        scope: str | None = None,
+        status: str = "open"
+    ) -> list[dict]:
+        """Get conflicts."""
+        ...
+    
+    @abstractmethod
+    async def resolve_conflict(
+        self,
+        conflict_id: str,
+        resolution_type: str,
+        resolution: str,
+    ) -> bool:
+        """Resolve conflict. Returns success."""
+        ...
+    
+    # ── Agent Operations ─────────────────────────────────────
+    
+    @abstractmethod
+    async def upsert_agent(self, agent: dict) -> None:
+        """Insert or update agent."""
+        ...
+    
+    @abstractmethod
+    async def get_agent(self, agent_id: str) -> dict | None:
+        """Get agent."""
+        ...
+    
+    @abstractmethod
+    async def list_agents(self) -> list[dict]:
+        """List all agents."""
+        ...
+    
+    # ── Analytics ───────────────────────────────────────
+    
+    @abstractmethod
+    async def get_stats(self) -> dict:
+        """Get workspace statistics."""
+        ...
+```
+
+## Storage Factory
+
+```python
+class StorageFactory:
+    """Create storage backend from connection string."""
+    
+    @staticmethod
+    def create(connection_string: str, workspace_id: str) -> StorageBackend:
+        """Create appropriate storage backend.
+        
+        Examples:
+            sqlite:///engram.db
+            postgres://user:pass@localhost:5432/engram
+            mysql://user:pass@localhost:3306/engram
+            dynamodb://table:engram us-east-1
+        """
+        if connection_string.startswith("postgres"):
+            return PostgresStorage(connection_string, workspace_id)
+        elif connection_string.startswith("mysql"):
+            return MySQLStorage(connection_string, workspace_id)
+        elif connection_string.startswith("dynamodb"):
+            return DynamoDBStorage(connection_string, workspace_id)
+        else:
+            return SQLiteStorage(connection_string, workspace_id)
+```
+
+## Implementation Checklist
+
+For each new backend:
+
+- [ ] Create `backend_<name>.py`
+- [ ] Implement `StorageBackend` interface
+- [ ] Add to `StorageFactory`
+- [ ] Write tests
+- [ ] Update documentation
+- [ ] Add connection string parser
+
+## Configuration
+
+### Via Environment
+
+```bash
+# SQLite (default)
+ENGRAM_DB_URL="sqlite:///path/to/engram.db"
+
+# PostgreSQL
+ENGRAM_DB_URL="postgres://user:pass@host:port/dbname"
+
+# MySQL  
+ENGRAM_DB_URL="mysql://user:pass@host:port/dbname"
+
+# DynamoDB
+ENGRAM_DB_URL="dynamodb://table:engram region:us-east-1"
+```
+
+### Via CLI
+
+```bash
+engram init --db-url postgres://user:pass@localhost:5432/engram
+```
+
+## Performance Notes
+
+| Backend | Read Speed | Write Speed | Scalability |
+|---------|-----------|-----------|-----------|
+| SQLite | Fast | Fast | Single user |
+| PostgreSQL | Fast | Fast | Unlimited |
+| MySQL | Fast | Fast | Unlimited |
+| DynamoDB | Very Fast | Medium | Serverless |
+
+## Migration
+
+```bash
+# Export from current backend
+engram export --format json > backup.json
+
+# Import to new backend
+NEW_DB_URL="mysql://..." engram import --format json backup.json
+```
+
+## Future Backends
+
+To request a new backend, open an issue with:
+- Use case
+- Expected scale
+- Preferred cloud provider

--- a/docs/WORKSPACE_FEDERATION.md
+++ b/docs/WORKSPACE_FEDERATION.md
@@ -1,0 +1,216 @@
+# Workspace Federation (Issue #12)
+
+## Overview
+
+Workspace federation allows two workspaces to connect and share knowledge **without merging** their data, enabling cross-team collaboration while maintaining isolation.
+
+## Use Cases
+
+1. **Security teams** sharing IOCs without exposing infrastructure
+2. **Platform teams** sharing patterns without exposing code
+3. **Multiple subteams** in large organizations
+4. **Contractors** getting read-only access to specific knowledge
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│           Federation Network                        │
+│                                              │
+│  Workspace A ─────► Proxy ─────► Workspace B   │
+│  (team-a)           ↕          (team-b)         │
+│  - facts: open     query     - facts: open      │
+│  - agents: own    respond  - agents: own       │
+└─────────────────────────────────────────────────────┘
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-----------|
+| **Federation link** | Connection between two workspaces |
+| **Proxy** | Forwards queries between workspaces |
+| **Read-through** | Query local, then federated |
+| **Remote facts** | Facts from linked workspace |
+
+## Data Sharing Modes
+
+| Mode | Local Write | Local Read | Federated Read | Federated Write |
+|------|-----------|----------|------------|-------------|
+| **Full** | ✅ | ✅ | ✅ | ❌ |
+| **Read-only** | ✅ | ✅ | ✅ | ❌ |
+| **Facts only** | ❌ | ✅ | ❌ | ❌ |
+
+### Detailed Permissions
+
+```
+Full:
+  - Can read all local facts
+  - Can read federated facts  
+  - Can write local facts
+  - Cannot write to remote
+
+Read-only:
+  - Can read all local facts
+  - Can read federated facts
+  - Cannot write local facts
+  - Cannot write to remote
+```
+
+## Implementation
+
+### Database Schema
+
+```sql
+-- Federation connections
+CREATE TABLE federation_links (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT REFERENCES workspaces(id),
+    remote_workspace_id TEXT,
+    mode TEXT CHECK (mode IN ('full', 'read-only', 'facts-only')),
+    secret_hash TEXT,
+    created_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(workspace_id, remote_workspace_id)
+);
+
+-- Cached remote facts (for performance)
+CREATE TABLE federated_facts_cache (
+    id TEXT,
+    workspace_id TEXT,
+    remote_fact_id TEXT,
+    remote_workspace_id TEXT,
+    content TEXT,
+    scope TEXT,
+    fetched_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (workspace_id, remote_fact_id)
+);
+```
+
+### API Endpoints
+
+```python
+# Create federation link
+POST /api/federation/link
+{
+    "remote_workspace_id": "ws-123",
+    "mode": "read-only",
+    "secret": "optional-secret"
+}
+
+# List federated facts
+GET /api/federation/facts?remote=ws-123
+
+# Query through federation
+GET /api/federation/query?topic=...
+
+# Accept link request
+POST /api/federation/link/accept
+
+# Revoke link
+DELETE /api/federation/link/{id}
+```
+
+### Query Flow
+
+```
+1. Agent queries local workspace
+2. If no results, check federated links
+3. For each linked workspace:
+   a. Authenticate with secret
+   b. Forward query
+   c. Merge results
+4. Return combined results
+```
+
+## Security
+
+### Secrets
+
+- Federation uses **shared secrets**
+- Each link has unique secret
+- Secrets hashed in database
+- Can be rotated independently
+
+### Isolation Guarantees
+
+- **No cross-workspace DELETE** - Can only read
+- **Local writes stay local** - Facts written locally only
+- **Audit logging** - All federation queries logged
+- **Revoke at any time** - Instant disconnection
+
+### Rate Limiting
+
+```python
+# Default limits
+FEDERATION_QUERY_RATE_LIMIT = 100  # per minute
+FEDERATION_RESULT_LIMIT = 50   # per query
+```
+
+## Usage Examples
+
+### CLI Commands
+
+```bash
+# Create federation link
+engram federation create --to team-b-workspace
+
+# List federated workspaces
+engram federation list
+
+# Query federated knowledge
+engram query --federated "API timeout"
+
+# Revoke link
+engram federation revoke team-b
+```
+
+### MCP Tool
+
+```
+engram_federate(
+    action="create",
+    workspace_id="ws-123",
+    mode="read-only"
+)
+
+engram_federate(
+    action="query",
+    query="API config",
+    federate=True
+)
+```
+
+## UI Integration
+
+### Dashboard
+
+- Show federated workspaces in sidebar
+- Badge for read-only vs full
+- Click to query federated knowledge
+
+### Conflict Detection
+
+- Conflicts can span workspaces
+- Local facts only shown
+- Cross-workspace conflicts flagged separately
+
+## Migration Path
+
+1. Add federation_links table
+2. Add federated_facts_cache table
+3. Implement proxy queries
+4. Add CLI commands
+5. Add dashboard UI
+6. Add rate limiting
+
+## Limitations
+
+- **Cross-workspace conflicts** - Not fully supported
+- **Write to remote** - Not allowed (by design)
+- **Nested federation** - Single hop only initially
+
+## Future Enhancements
+
+- Multi-hop federation (A→B→C)
+- Selective fact sharing (by scope)
+- Real-time sync via webhooks


### PR DESCRIPTION
## Summary

Added design document for workspace federation.

## New File
- `docs/WORKSPACE_FEDERATION.md` - Complete design

## Contents

- Federation architecture (workspace linking)
- 3 sharing modes: full, read-only, facts-only
- API endpoints and query flow
- Security and isolation guarantees
- CLI commands
- Limitations and future enhancements

## Addressed Issue

#12: "Workspace federation: connect two workspaces without merging them"