### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[Bug]: "
+labels: bug, enhancement
+assignees: ''
+
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04, macOS 14]
+- Python version: [e.g., 3.11.0]
+- Docker version (if applicable): [e.g., 24.0.0]
+
+## Configuration
+
+Relevant parts of your agent configuration or environment setup (remove any sensitive data):
+
+```yaml
+# paste here
+```
+
+## Logs
+
+Relevant log output:
+
+```
+paste logs here
+```
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+
+---
+
+## Problem Statement
+
+A clear and concise description of what problem this feature would solve.
+
+Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A description of any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or screenshots about the feature request here.
+
+## Implementation Ideas
+
+If you have ideas about how this could be implemented, share them here.


### PR DESCRIPTION
## Description

Adds GitHub issue templates for bug reports and feature requests so contributors can submit more consistent and actionable issues.

## Type of Change

- Documentation update

## Related Issues

Fixes #289 

## Changes Made

- Added `.github/ISSUE_TEMPLATE/bug_report.md`
- Added `.github/ISSUE_TEMPLATE/feature_request.md`

## Testing

Describe the tests you ran to verify your changes:

- Verified both issue template files are present under `.github/ISSUE_TEMPLATE/`
- Manual review of template structure

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have made corresponding changes to the documentation
- My changes generate no new warnings
