### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Description
+
+Brief description of the changes in this PR.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related Issues
+
+Fixes #(issue number)
+
+## Changes Made
+
+- Change 1
+- Change 2
+- Change 3
+
+## Testing
+
+Describe the tests you ran to verify your changes:
+
+- [ ] Unit tests pass (`cd core && pytest tests/`)
+- [ ] Lint passes (`cd core && ruff check .`)
+- [ ] Manual testing performed
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+## Screenshots (if applicable)
+
+Add screenshots if you can .


### PR DESCRIPTION
## Description

Adds a default GitHub pull request template so contributors provide consistent context when opening PRs.

## Type of Change

- Documentation update

## Related Issues

Fixes #290 

## Changes Made

- Added `.github/PULL_REQUEST_TEMPLATE.md`

## Testing

Describe the tests you ran to verify your changes:

- Verified `.github/PULL_REQUEST_TEMPLATE.md` is present
- Manually reviewed the template structure

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have made corresponding changes to the documentation
- My changes generate no new warnings