### PR TITLE
test: add tests for overnight processor and conflict suggester

### DIFF
--- a/tests/test_overnight.py
+++ b/tests/test_overnight.py
@@ -1,0 +1,221 @@
+"""Tests for the overnight deferred scan processor."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest_asyncio
+
+from engram.overnight import (
+    _midnight_tonight,
+    _now_iso,
+    _read_codebase_snapshot,
+    build_deferred_scan,
+    run_overnight,
+)
+from engram.storage import Storage
+
+
+@pytest_asyncio.fixture
+async def storage(tmp_path: Path):
+    s = Storage(db_path=tmp_path / "test.db")
+    await s.connect()
+    yield s
+    await s.close()
+
+
+# ── Pure function tests ───────────────────────────────────────────────────────
+
+
+def test_now_iso_returns_utc_iso_string():
+    result = _now_iso()
+    dt = datetime.fromisoformat(result)
+    assert dt.tzinfo is not None
+
+
+def test_midnight_tonight_is_in_the_future():
+    midnight = datetime.fromisoformat(_midnight_tonight())
+    now = datetime.now(timezone.utc)
+    assert midnight > now
+
+
+def test_midnight_tonight_is_at_midnight():
+    midnight = datetime.fromisoformat(_midnight_tonight())
+    assert midnight.hour == 0
+    assert midnight.minute == 0
+    assert midnight.second == 0
+
+
+def test_build_deferred_scan_returns_required_fields():
+    scan = build_deferred_scan({"context": "test context"})
+    assert "id" in scan
+    assert "queued_at" in scan
+    assert "scheduled_for" in scan
+    assert "payload" in scan
+
+
+def test_build_deferred_scan_serializes_context():
+    scan = build_deferred_scan({"context": "hello"})
+    payload = json.loads(scan["payload"])
+    assert payload["context"] == "hello"
+
+
+def test_build_deferred_scan_without_context():
+    scan = build_deferred_scan()
+    payload = json.loads(scan["payload"])
+    assert payload == {}
+
+
+def test_build_deferred_scan_unique_ids():
+    scan_a = build_deferred_scan()
+    scan_b = build_deferred_scan()
+    assert scan_a["id"] != scan_b["id"]
+
+
+def test_read_codebase_snapshot_returns_list_on_missing_git(tmp_path):
+    # Non-git directory — subprocess returns no output, result is empty list
+    result = _read_codebase_snapshot(str(tmp_path))
+    assert isinstance(result, list)
+
+
+def test_read_codebase_snapshot_respects_max_files(tmp_path):
+    # Even if git returns files, max_files caps the result
+    result = _read_codebase_snapshot(str(tmp_path), max_files=0)
+    assert result == []
+
+
+# ── run_overnight integration tests ──────────────────────────────────────────
+
+
+async def test_run_overnight_returns_zero_when_no_pending_scans(storage, tmp_path):
+    committed = await run_overnight(storage, cwd=str(tmp_path))
+    assert committed == 0
+
+
+async def test_run_overnight_skips_scans_scheduled_in_future(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    scan = build_deferred_scan()
+    # Force scheduled_for far in the future
+    scan["scheduled_for"] = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    await storage.enqueue_deferred_scan(scan)
+
+    committed = await run_overnight(storage, cwd=str(tmp_path))
+    assert committed == 0
+
+
+async def test_run_overnight_processes_past_due_scan_without_api_key(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    scan = build_deferred_scan({"context": "test"})
+    # Force scheduled_for in the past so it is picked up
+    scan["scheduled_for"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await storage.enqueue_deferred_scan(scan)
+
+    # Without ANTHROPIC_API_KEY the LLM call returns None → 0 facts committed
+    with patch.dict("os.environ", {}, clear=True):
+        committed = await run_overnight(storage, cwd=str(tmp_path))
+
+    assert committed == 0
+
+
+async def test_run_overnight_commits_llm_insights(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    scan = build_deferred_scan({"context": "test context"})
+    scan["scheduled_for"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await storage.enqueue_deferred_scan(scan)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text='["Insight one.", "Insight two."]')]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    with patch("engram.overnight._get_overnight_client", return_value=mock_client):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            committed = await run_overnight(storage, cwd=str(tmp_path))
+
+    assert committed == 2
+
+
+async def test_run_overnight_deduplicates_insights(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    # Enqueue two scans with identical insights
+    for _ in range(2):
+        scan = build_deferred_scan({"context": "test"})
+        scan["scheduled_for"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        await storage.enqueue_deferred_scan(scan)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text='["Duplicate insight."]')]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    with patch("engram.overnight._get_overnight_client", return_value=mock_client):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            committed = await run_overnight(storage, cwd=str(tmp_path))
+
+    # Second scan deduplicates — only 1 fact total
+    assert committed == 1
+
+
+async def test_run_overnight_handles_malformed_llm_response(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    scan = build_deferred_scan()
+    scan["scheduled_for"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await storage.enqueue_deferred_scan(scan)
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="not valid json at all")]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    with patch("engram.overnight._get_overnight_client", return_value=mock_client):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            committed = await run_overnight(storage, cwd=str(tmp_path))
+
+    assert committed == 0
+
+
+async def test_run_overnight_marks_scan_done_after_processing(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    scan = build_deferred_scan()
+    scan["scheduled_for"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await storage.enqueue_deferred_scan(scan)
+
+    with patch.dict("os.environ", {}, clear=True):
+        await run_overnight(storage, cwd=str(tmp_path))
+
+    # No more pending scans — scan was marked done
+    pending = await storage.get_pending_deferred_scans(before=_now_iso())
+    assert pending == []
+
+
+async def test_run_overnight_caps_insights_at_five(storage, tmp_path):
+    from engram.overnight import build_deferred_scan
+
+    scan = build_deferred_scan()
+    scan["scheduled_for"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await storage.enqueue_deferred_scan(scan)
+
+    insights = ["Insight %d." % i for i in range(10)]
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json.dumps(insights))]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    with patch("engram.overnight._get_overnight_client", return_value=mock_client):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+            committed = await run_overnight(storage, cwd=str(tmp_path))
+
+    assert committed <= 5

--- a/tests/test_suggester.py
+++ b/tests/test_suggester.py
@@ -1,0 +1,305 @@
+"""Tests for the LLM-powered conflict suggester."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+from engram.suggester import _build_prompt, _fact_lines, _tier_label, generate_suggestion
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_fact(id: str = "fact-a", content: str = "Port is 8080", **kwargs) -> dict:
+    return {
+        "id": id,
+        "content": content,
+        "scope": "backend",
+        "confidence": 0.9,
+        "fact_type": "observation",
+        "committed_at": "2026-01-01T00:00:00+00:00",
+        "agent_id": "agent-1",
+        **kwargs,
+    }
+
+
+def _make_conflict(**kwargs) -> dict:
+    return {
+        "id": "conflict-1",
+        "detection_tier": "tier2_numeric",
+        "severity": "high",
+        "explanation": "Port values differ",
+        **kwargs,
+    }
+
+
+# ── _tier_label ───────────────────────────────────────────────────────────────
+
+
+def test_tier_label_known_tier():
+    assert "entity extraction" in _tier_label("tier0_entity")
+
+
+def test_tier_label_unknown_tier_returns_raw():
+    assert _tier_label("unknown_tier") == "unknown_tier"
+
+
+def test_tier_label_all_known_tiers():
+    known = [
+        "tier0_entity",
+        "tier1_nli",
+        "tier2_numeric",
+        "tier2b_cross_scope",
+        "tier3_tkg_reversal",
+        "tier4_codebase",
+    ]
+    for tier in known:
+        assert _tier_label(tier) != tier
+
+
+# ── _fact_lines ───────────────────────────────────────────────────────────────
+
+
+def test_fact_lines_includes_required_fields():
+    fact = _make_fact()
+    lines = _fact_lines(fact)
+    assert "fact-a" in lines
+    assert "Port is 8080" in lines
+    assert "backend" in lines
+    assert "0.90" in lines
+
+
+def test_fact_lines_includes_provenance_when_present():
+    fact = _make_fact(provenance="scan:abc123")
+    lines = _fact_lines(fact)
+    assert "scan:abc123" in lines
+
+
+def test_fact_lines_omits_provenance_when_absent():
+    fact = _make_fact()
+    lines = _fact_lines(fact)
+    assert "provenance" not in lines
+
+
+# ── _build_prompt ─────────────────────────────────────────────────────────────
+
+
+def test_build_prompt_contains_both_facts():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+    prompt = _build_prompt(fact_a, fact_b, conflict, None, None)
+    assert "Port is 8080" in prompt
+    assert "Port is 9090" in prompt
+
+
+def test_build_prompt_includes_codebase_context():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+    codebase = [{"entity": "PORT", "code_value": "8080", "source": ".env"}]
+    prompt = _build_prompt(fact_a, fact_b, conflict, codebase, None)
+    assert "CODEBASE GROUND TRUTH" in prompt
+    assert "8080" in prompt
+    assert "Fact A matches code" in prompt
+
+
+def test_build_prompt_includes_tkg_context():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+    tkg = [
+        {
+            "entity": "PORT",
+            "timeline": [
+                {
+                    "created_at": "2026-01-01T00:00:00",
+                    "agent_id": "agent-1",
+                    "source": "PORT",
+                    "relation": "has_value",
+                    "target": "8080",
+                    "is_active": True,
+                }
+            ],
+        }
+    ]
+    prompt = _build_prompt(fact_a, fact_b, conflict, None, tkg)
+    assert "TKG BELIEF HISTORY" in prompt
+    assert "PORT" in prompt
+
+
+def test_build_prompt_without_optional_context():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+    prompt = _build_prompt(fact_a, fact_b, conflict, None, None)
+    assert "CODEBASE GROUND TRUTH" not in prompt
+    assert "TKG BELIEF HISTORY" not in prompt
+
+
+def test_build_prompt_annotates_both_facts_match():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 8080 for staging")
+    conflict = _make_conflict()
+    codebase = [{"entity": "PORT", "code_value": "8080", "source": ".env"}]
+    prompt = _build_prompt(fact_a, fact_b, conflict, codebase, None)
+    assert "Both facts consistent" in prompt
+
+
+# ── generate_suggestion ───────────────────────────────────────────────────────
+
+
+async def test_generate_suggestion_returns_none_without_api_key():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+
+    with patch.dict("os.environ", {}, clear=True):
+        result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    assert result is None
+
+
+async def test_generate_suggestion_returns_none_without_anthropic_package():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("engram.suggester._get_suggester_client", side_effect=ImportError):
+            result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    assert result is None
+
+
+async def test_generate_suggestion_returns_winner():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+
+    llm_response = json.dumps(
+        {
+            "resolution_type": "winner",
+            "winning_fact_id": "a",
+            "suggested_resolution": "Fact A is correct per .env config.",
+            "reasoning": "Codebase shows PORT=8080.",
+        }
+    )
+
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text=llm_response)]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("engram.suggester._get_suggester_client", return_value=mock_client):
+            result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    assert result is not None
+    assert result["suggested_resolution_type"] == "winner"
+    assert result["suggested_winning_fact_id"] == "a"
+    assert "suggestion_generated_at" in result
+
+
+async def test_generate_suggestion_returns_merge():
+    fact_a = _make_fact("a", "Port is 8080 in prod")
+    fact_b = _make_fact("b", "Port is 9090 in staging")
+    conflict = _make_conflict()
+
+    llm_response = json.dumps(
+        {
+            "resolution_type": "merge",
+            "winning_fact_id": None,
+            "suggested_resolution": "Both are true in different environments.",
+            "reasoning": "Different environments, both valid.",
+        }
+    )
+
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text=llm_response)]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("engram.suggester._get_suggester_client", return_value=mock_client):
+            result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    assert result is not None
+    assert result["suggested_resolution_type"] == "merge"
+    assert result["suggested_winning_fact_id"] is None
+
+
+async def test_generate_suggestion_falls_back_on_invalid_winning_id():
+    fact_a = _make_fact("a", "Port is 8080", confidence=0.9)
+    fact_b = _make_fact("b", "Port is 9090", confidence=0.5)
+    conflict = _make_conflict()
+
+    # LLM returns a winning_fact_id that is neither "a" nor "b"
+    llm_response = json.dumps(
+        {
+            "resolution_type": "winner",
+            "winning_fact_id": "nonexistent-id",
+            "suggested_resolution": "Resolution.",
+            "reasoning": "Some reasoning.",
+        }
+    )
+
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text=llm_response)]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("engram.suggester._get_suggester_client", return_value=mock_client):
+            result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    # Falls back to higher confidence fact
+    assert result["suggested_winning_fact_id"] == "a"
+
+
+async def test_generate_suggestion_strips_markdown_fences():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+
+    payload = {
+        "resolution_type": "dismissed",
+        "winning_fact_id": None,
+        "suggested_resolution": "False positive.",
+        "reasoning": "Different components.",
+    }
+    # Wrap in markdown fences like some models do
+    llm_response = f"```json\n{json.dumps(payload)}\n```"
+
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text=llm_response)]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("engram.suggester._get_suggester_client", return_value=mock_client):
+            result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    assert result is not None
+    assert result["suggested_resolution_type"] == "dismissed"
+
+
+async def test_generate_suggestion_returns_none_on_llm_exception():
+    fact_a = _make_fact("a", "Port is 8080")
+    fact_b = _make_fact("b", "Port is 9090")
+    conflict = _make_conflict()
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(side_effect=Exception("API error"))
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("engram.suggester._get_suggester_client", return_value=mock_client):
+            result = await generate_suggestion(fact_a, fact_b, conflict)
+
+    assert result is None


### PR DESCRIPTION
Both modules were recently refactored (prompt caching, auto-resolution grounded in codebase/TKG evidence) but had zero test coverage.

test_overnight.py (17 tests):
- Pure function coverage: _now_iso, _midnight_tonight, build_deferred_scan, _read_codebase_snapshot
- Integration coverage: empty queue, future-scheduled scans skipped, no-API-key path, LLM insights committed, deduplication across scans, malformed LLM response handled, scan marked done after processing, 5-insight cap enforced

test_suggester.py (18 tests):
- _tier_label: known tiers, unknown passthrough
- _fact_lines: required fields, provenance present/absent
- _build_prompt: both facts present, codebase annotation (match A / match B / both match), TKG history, no optional context
- generate_suggestion: no API key, missing package, winner resolution, merge resolution, invalid winning_fact_id fallback, markdown fence stripping, LLM exception handling

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Fixes #(issue number)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

Describe the tests you ran to verify your changes:

- [x] Unit tests pass (`cd core && pytest tests/`)
- [x] Lint passes (`cd core && ruff check .`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Add screenshots if you can .