### PR TITLE
fix: resolve asyncpg str vs datetime TypeError in invite key creation

### DIFF
--- a/src/engram/engine.py
+++ b/src/engram/engine.py
@@ -3069,7 +3069,7 @@ class EngramEngine:
         )
         expires_ts = datetime.fromtimestamp(
             time.time() + expires_days * 86400, tz=timezone.utc
-        ).isoformat()
+        )
         await self.storage.insert_invite_key(
             key_hash=key_hash,
             engram_id=ws.engram_id,

--- a/src/engram/postgres_storage.py
+++ b/src/engram/postgres_storage.py
@@ -1419,7 +1419,7 @@ class PostgresStorage(BaseStorage):
         self,
         key_hash: str,
         engram_id: str,
-        expires_at: str | None,
+        expires_at: datetime | None,
         uses_remaining: int | None,
     ) -> None:
         async with self.acquire() as conn:

--- a/src/engram/server.py
+++ b/src/engram/server.py
@@ -358,7 +358,7 @@ async def engram_status() -> dict[str, Any]:
                 )
                 expires_ts = datetime.fromtimestamp(
                     time.time() + 90 * 86400, tz=timezone.utc
-                ).isoformat()
+                )
                 await _storage.insert_invite_key(
                     key_hash=key_hash,
                     engram_id=ws.engram_id,
@@ -529,7 +529,7 @@ async def engram_init(
 
         expires_ts = datetime.fromtimestamp(
             time.time() + invite_expires_days * 86400, tz=timezone.utc
-        ).isoformat()
+        )
 
         await _storage.ensure_workspace(engram_id, anonymous_mode, anon_agents)
         await _storage.insert_invite_key(

--- a/src/engram/storage.py
+++ b/src/engram/storage.py
@@ -316,7 +316,7 @@ class BaseStorage(ABC):
         self,
         key_hash: str,
         engram_id: str,
-        expires_at: str | None,
+        expires_at: datetime | None,
         uses_remaining: int | None,
     ) -> None:
         """Store an invite key hash. Default no-op for local mode."""
@@ -1962,14 +1962,16 @@ class SQLiteStorage(BaseStorage):
         self,
         key_hash: str,
         engram_id: str,
-        expires_at: str | None,
+        expires_at: datetime | None,
         uses_remaining: int | None,
     ) -> None:
         now = _now_iso()
+        # SQLite expects ISO strings for datetime comparison
+        expires_str = expires_at.isoformat() if expires_at else None
         await self.db.execute(
             """INSERT OR IGNORE INTO invite_keys(key_hash, engram_id, created_at, expires_at, uses_remaining)
                VALUES (?, ?, ?, ?, ?)""",
-            (key_hash, engram_id, now, expires_at, uses_remaining),
+            (key_hash, engram_id, now, expires_str, uses_remaining),
         )
         await self.db.commit()
 


### PR DESCRIPTION
## Summary

Fixes `asyncpg.exceptions.DataError` when calling `engram_init` / `engram_status` / `rotate_invite_key` — the expiry datetime was serialized to an ISO string via `.isoformat()`, but asyncpg's `TIMESTAMPTZ` columns expect a `datetime.datetime` object.

## Root Cause

Three call sites called `.isoformat()` on the expiry datetime before passing it to storage:

1. `server.py:engram_init` (L532)
2. `server.py:engram_status` (L361)
3. `engine.py:rotate_invite_key` (L3072)

Additionally, the type hints in `storage.py` (base + SQLiteStorage) and `postgres_storage.py` declared `expires_at: str | None`, misleading callers into thinking strings were acceptable for the Postgres backend.

## Changes

### Commit 1 — Type hints
- `storage.py`: `Storage.insert_invite_key` (base class) + `SQLiteStorage.insert_invite_key`: `expires_at: str | None` → `datetime | None`
- `postgres_storage.py`: `PostgresStorage.insert_invite_key`: `expires_at: str | None` → `datetime | None`

### Commit 2 — Call sites
- `server.py` lines 361, 532: removed `.isoformat()`
- `engine.py` line 3072: removed `.isoformat()`

### Why SQLiteStorage still has `.isoformat()`

SQLite uses TEXT columns, so the SQLiteStorage implementation correctly continues to call `.isoformat()` internally — that's its concern, not the caller's. The interface now accurately reflects both backends' requirements.

## Verification

- All type hints confirmed as `datetime | None` (not `str | None`)
- No `.isoformat()` calls remain in the Postgres-bound insert_invite_key paths
- SQLiteStorage correctly retains its internal `.isoformat()` for TEXT column storage
- All imports and module-level AST verification pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected invite key expiration timestamp calculations to ensure accurate date computations across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Agentscreator/engram-memory/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->